### PR TITLE
ui: #01 이미지 리사이징 메소드 수정

### DIFF
--- a/Projects/DesignSystem/Sources/+UIImage.swift
+++ b/Projects/DesignSystem/Sources/+UIImage.swift
@@ -26,6 +26,22 @@ public extension UIImage {
   static let landing = DesignSystemAsset.landing.image.withRenderingMode(.alwaysTemplate)
   static let takeOff = DesignSystemAsset.takeOff.image.withRenderingMode(.alwaysTemplate)
   
+  // MARK: - Public Method
+  /// UIImage의 크기를 지정한 width, height로 리사이즈하여 새로운 이미지를 반환합니다.
+  ///
+  /// 기존 이미지의 `renderingMode`를 유지하여 template 이미지의 경우 `tintColor`가 정상적으로 적용됩니다.
+  ///
+  /// - Parameters:
+  ///   - width: 변경할 이미지의 너비 (pt 단위)
+  ///   - height: 변경할 이미지의 높이
+  /// - Returns: 지정한 크기로 리사이즈된 `UIImage`
+  ///
+  /// Example:
+  /// ```swift
+  /// let icon = UIImage.takeOff.resized(24, 24)
+  /// button.setImage(icon, for: .normal)
+  /// button.tintColor = .key0
+  /// ```
   func resized(_ width: Int, _ height: Int) -> UIImage {
     let size = CGSize(width: width, height: height)
     let rendered = UIGraphicsImageRenderer(size: size).image { _ in


### PR DESCRIPTION
resized 메소드 구현

## 관련 이슈 (Related Issue)

<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->

- Closes #1 

---

## 작업 내용

<!-- 무엇을 변경했는지 간단히 설명 -->

- 매개변수 타입 수정

---

## 변경 사항

<!-- 주요 변경 사항을 작성 -->

- CGSize 타입을 따로 Int 타입으로 받아 메소드 안에서 타입 변환 후 계산하도록 수정

---

## 스크린샷 / 영상 (UI 변경 시)

| Before | After |
| ------ | ----- |
|        |       |

---

## 테스트

- [x] 로컬 빌드 확인
- [x] 시뮬레이터 실행
- [ ] 테스트 코드 통과
- [ ] CI 통과

---

## 영향 범위

- [x] App
- [ ] Core
- [x] DesignSystem
- [x] Feature
- [ ] Tuist
- [ ] CI / Fastlane

---

## 리뷰 포인트

<!-- 리뷰어가 집중해서 보면 좋은 부분 -->

```swift
btn.setImage(.takeOff.resized(to: CGSize(width: 24, height: 24)), for: .normal) // 변경 전
btn.setImage(.takeOff.resized(24, 24), for: .normal) // 변경 후
```

---

## 레퍼런스

<!-- 참고했던 레퍼런스 등 -->

---

## 체크리스트

- [x] 불필요한 코드 제거
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트
- [ ] CI 통과