### PR TITLE
refactor:#92 ReadingJourneyService 중복 로직 개선

### DIFF
--- a/Services/ReadingJourney/ReadingJourneyImplementation/Sources/JourneyMemoService.swift
+++ b/Services/ReadingJourney/ReadingJourneyImplementation/Sources/JourneyMemoService.swift
@@ -10,6 +10,18 @@ import FirebaseAuth
 import FirebaseFirestore
 import Foundation
 
+/// Firestore를 이용해 독서 여행 메모를 생성, 조회, 수정, 삭제하는 서비스입니다.
+///
+/// ```swift
+/// let service = JourneyMemoService()
+/// try await service.createMemo(journeyId: journeyId, memo: memo)
+/// let memos = try await service.fetchMemos(journeyId: journeyId)
+/// ```
+///
+/// - Note:
+///   - Firebase Authentication을 통해 현재 로그인된 사용자(uid)를 기준으로 메모가 저장됩니다.
+///   - 메모는 각 독서 여행(`readingJourneys/{journeyId}`) 문서 하위의 `memos` 컬렉션에 저장됩니다.
+///   - 메모 조회 시 `createdAt` 기준 내림차순으로 정렬됩니다.
 public final class JourneyMemoService: JourneyMemoServicing {
   private let auth: Auth
   private let db: Firestore
@@ -22,78 +34,124 @@ public final class JourneyMemoService: JourneyMemoServicing {
     self.db = db
   }
   
+  // MARK: - Create
+  
+  /// 특정 독서 여행에 메모를 생성합니다.
+  ///
+  /// - Parameters:
+  ///   - journeyId: 메모를 추가할 독서 여행 문서 ID
+  ///   - memo: 저장할 메모 모델
+  ///
+  /// - Throws:
+  ///   - `JourneyMemoError.unauthenticated`: 로그인된 사용자가 없는 경우
+  ///   - 기타 Firestore 인코딩/저장 오류
+  ///
+  /// - Important:
+  ///   - 메모 문서 ID는 `memo.id` 값을 사용합니다.
   public func createMemo(
     journeyId: String,
     memo: JourneyMemo
   ) async throws {
-    guard let uid = auth.currentUser?.uid else {
-      throw JourneyMemoError.unauthenticated
-    }
+    let uid = try currentUserId()
     
-    try db
-      .collection("users")
-      .document(uid)
-      .collection("readingJourneys")
-      .document(journeyId)
-      .collection("memos")
+    try memosCollection(uid: uid, journeyId: journeyId)
       .document(memo.id)
       .setData(from: memo)
   }
   
-  public func updateMemo(
-    journeyId: String,
-    memo: JourneyMemo
-  ) async throws {
-    guard let uid = auth.currentUser?.uid else {
-      throw JourneyMemoError.unauthenticated
-    }
-    
-    try db
-      .collection("users")
-      .document(uid)
-      .collection("readingJourneys")
-      .document(journeyId)
-      .collection("memos")
-      .document(memo.id)
-      .setData(from: memo, merge: true)
-  }
+  // MARK: - Read
   
+  /// 특정 독서 여행의 메모 목록을 조회합니다.
+  ///
+  /// - Parameter journeyId: 메모를 조회할 독서 여행 문서 ID
+  /// - Returns: `createdAt` 기준 내림차순으로 정렬된 `JourneyMemo` 배열
+  ///
+  /// - Throws:
+  ///   - `JourneyMemoError.unauthenticated`: 로그인된 사용자가 없는 경우
+  ///   - Firestore 조회/디코딩 오류
+  ///
+  /// - Note:
+  ///   - 조회된 문서는 `JourneyMemo` 모델로 디코딩됩니다.
   public func fetchMemos(
     journeyId: String
   ) async throws -> [JourneyMemo] {
-    guard let uid = auth.currentUser?.uid else {
-      throw JourneyMemoError.unauthenticated
-    }
+    let uid = try currentUserId()
     
-    let snapshot = try await db
-      .collection("users")
-      .document(uid)
-      .collection("readingJourneys")
-      .document(journeyId)
-      .collection("memos")
+    let snapshot = try await memosCollection(uid: uid, journeyId: journeyId)
       .order(by: "createdAt", descending: true)
       .getDocuments()
     
-    return try snapshot.documents.compactMap {
+    return try snapshot.documents.map {
       try $0.data(as: JourneyMemo.self)
     }
   }
   
+  // MARK: - Update
+  
+  /// 특정 독서 여행의 메모를 수정합니다.
+  ///
+  /// - Parameters:
+  ///   - journeyId: 수정할 메모가 속한 독서 여행 문서 ID
+  ///   - memo: 수정할 메모 모델
+  ///
+  /// - Throws:
+  ///   - `JourneyMemoError.unauthenticated`: 로그인된 사용자가 없는 경우
+  ///   - 기타 Firestore 인코딩/저장 오류
+  ///
+  /// - Important:
+  ///   - `merge: true` 옵션으로 저장되므로 기존 문서의 일부 필드만 갱신할 수 있습니다.
+  ///   - 수정 대상 문서 ID는 `memo.id` 값을 사용합니다.
+  public func updateMemo(
+    journeyId: String,
+    memo: JourneyMemo
+  ) async throws {
+    let uid = try currentUserId()
+    
+    try memosCollection(uid: uid, journeyId: journeyId)
+      .document(memo.id)
+      .setData(from: memo, merge: true)
+  }
+  
+  // MARK: - Delete
+  
+  /// 특정 독서 여행의 메모를 삭제합니다.
+  ///
+  /// - Parameters:
+  ///   - journeyId: 삭제할 메모가 속한 독서 여행 문서 ID
+  ///   - memoId: 삭제할 메모 문서 ID
+  ///
+  /// - Throws:
+  ///   - `JourneyMemoError.unauthenticated`: 로그인된 사용자가 없는 경우
+  ///   - 기타 Firestore 삭제 오류
   public func deleteMemo(
     journeyId: String,
     memoId: String
   ) async throws {
+    let uid = try currentUserId()
+    
+    try await memosCollection(uid: uid, journeyId: journeyId)
+      .document(memoId)
+      .delete()
+  }
+}
+
+// MARK: - Helper
+private extension JourneyMemoService {
+  func currentUserId() throws -> String {
     guard let uid = auth.currentUser?.uid else {
       throw JourneyMemoError.unauthenticated
     }
-    
-    try await db
-      .collection("users")
+    return uid
+  }
+  
+  func memosCollection(
+    uid: String,
+    journeyId: String
+  ) -> CollectionReference {
+    db.collection("users")
       .document(uid)
       .collection("readingJourneys")
       .document(journeyId)
       .collection("memos")
-      .document(memoId)
-      .delete()
   }
 }

--- a/Services/ReadingJourney/ReadingJourneyImplementation/Sources/ReadingJourneyService.swift
+++ b/Services/ReadingJourney/ReadingJourneyImplementation/Sources/ReadingJourneyService.swift
@@ -6,10 +6,10 @@
 //
 
 import Core
-import ReadingJourneyInterface
 import FirebaseAuth
 import FirebaseFirestore
 import Foundation
+import ReadingJourneyInterface
 
 /// Firestore를 이용해 독서 여행을 생성 및 관리하는 서비스입니다.
 ///
@@ -36,159 +36,7 @@ public final class ReadingJourneyService: ReadingJourneyServicing {
     self.db = db
   }
   
-  /// 위시리스트(읽고 싶은 책) 상태의 독서 여행을 생성합니다.
-  ///
-  /// - Parameter payload: 책, 출발지, 도착지, 이유 등을 포함한 생성 데이터
-  /// - Returns: 생성된 `ReadingJourney` 모델
-  ///
-  /// - Throws:
-  ///   - `ReadingJourneyError.unauthenticated`: 로그인된 사용자가 없는 경우
-  ///   - `ReadingJourneyError.duplicateJourney`: 동일 노선의 진행 중 여행이 이미 존재하는 경우
-  ///   - 기타 Firestore 네트워크/저장 오류
-  ///
-  /// - Important:
-  ///   - 동일한 출발지 + 도착지 조합에 대해
-  ///   - Firestore에는 `nil` 값을 직접 저장할 수 없기 때문에
-  ///     일부 필드는 `NSNull()`로 저장됩니다.
-  ///   - `reason`이 비어있는 경우, 기본 문구가 랜덤으로 저장됩니다.
-  public func createWishlistJourney(
-    payload: WishlistTicketPayload
-  ) async throws -> ReadingJourney {
-    guard let uid = auth.currentUser?.uid else {
-      throw ReadingJourneyError.unauthenticated
-    }
-    
-    let distanceKm = Double(
-      AirportInfo.distanceKm(from: payload.departure, to: payload.destination)
-    )
-    let now = Date()
-    
-    let journeysRef = db
-      .collection("users")
-      .document(uid)
-      .collection("readingJourneys")
-    
-    let trimmedReason = payload.reason.trimmingCharacters(in: .whitespacesAndNewlines)
-    let finalReason = trimmedReason.isEmpty ? ReasonProvider.random() : trimmedReason
-    
-    let documentRef = journeysRef.document()
-    
-    let document: [String: Any] = [
-      "status": ReadingJourneyStatusType.wishlist.rawValue,
-      "departureAirport": departureAirportDictionary(payload.departure),
-      "arrivalAirport": arrivalAirportDictionary(payload.destination),
-      "distanceKm": distanceKm,
-      "remainingDistanceKm": distanceKm,
-      "book": bookDictionary(payload.book),
-      "reason": finalReason,
-      "startedAt": NSNull(),
-      "finishedAt": NSNull(),
-      "currentPage": NSNull(),
-      "progressUpdatedAt": NSNull(),
-      "review": NSNull(),
-      "createdAt": now,
-      "updatedAt": NSNull(),
-      "lastUpdatedAt": now
-    ]
-    
-    try await documentRef.setData(document)
-    
-    return ReadingJourney(
-      id: documentRef.documentID,
-      status: .wishlist,
-      departureAirport: payload.departure,
-      arrivalAirport: payload.destination,
-      distanceKm: distanceKm,
-      remainingDistanceKm: distanceKm,
-      book: payload.book,
-      reason: finalReason,
-      startedAt: nil,
-      finishedAt: nil,
-      currentPage: nil,
-      progressUpdatedAt: nil,
-      review: nil,
-      createdAt: now,
-      updatedAt: nil,
-      lastUpdatedAt: now
-    )
-  }
-  
-  
-  /// 히스토리(다 읽은 책) 상태의 독서 여행을 생성합니다.
-  ///
-  /// - Parameter payload: 책, 출발지, 도착지, 시작일, 종료일, 감상평 등을 포함한 생성 데이터
-  /// - Returns: 생성된 `ReadingJourney` 모델
-  ///
-  /// - Throws:
-  ///   - `ReadingJourneyError.unauthenticated`: 로그인된 사용자가 없는 경우
-  ///   - `ReadingJourneyError.duplicateJourney`: 동일 노선의 진행 중 여행이 이미 존재하는 경우
-  ///   - 기타 Firestore 네트워크/저장 오류
-  ///
-  /// - Important:
-  ///   - 동일한 출발지 + 도착지 조합에 대해
-  ///     `wishlist` 또는 `reading` 상태가 존재하면 생성이 차단됩니다.
-  ///   - Firestore에는 `nil` 값을 직접 저장할 수 없기 때문에
-  ///     일부 필드는 `NSNull()`로 저장됩니다.
-  public func createHistoryJourney(
-    payload: HistoryPayload
-  ) async throws -> ReadingJourney {
-    guard let uid = auth.currentUser?.uid else {
-      throw ReadingJourneyError.unauthenticated
-    }
-    
-    let distanceKm = Double(
-      AirportInfo.distanceKm(from: payload.departureAirport, to: payload.destinationAirport)
-    )
-    let now = Date()
-    
-    let journeysRef = db
-      .collection("users")
-      .document(uid)
-      .collection("readingJourneys")
-    
-    let documentRef = journeysRef.document()
-    
-    let trimmedReview = payload.review.trimmingCharacters(in: .whitespacesAndNewlines)
-    
-    let document: [String: Any] = [
-      "status": ReadingJourneyStatusType.finished.rawValue,
-      "departureAirport": departureAirportDictionary(payload.departureAirport),
-      "arrivalAirport": arrivalAirportDictionary(payload.destinationAirport),
-      "distanceKm": distanceKm,
-      "remainingDistanceKm": 0,
-      "book": bookDictionary(payload.book),
-      "reason": NSNull(),
-      "startedAt": payload.startDate,
-      "finishedAt": payload.finishDate,
-      "currentPage": payload.book.itemPage,
-      "progressUpdatedAt": payload.finishDate,
-      "review": trimmedReview.isEmpty ? NSNull() : trimmedReview,
-      "createdAt": now,
-      "updatedAt": NSNull(),
-      "lastUpdatedAt": now
-    ]
-    
-    try await documentRef.setData(document)
-    
-    return ReadingJourney(
-      id: documentRef.documentID,
-      status: .finished,
-      departureAirport: payload.departureAirport,
-      arrivalAirport: payload.destinationAirport,
-      distanceKm: distanceKm,
-      remainingDistanceKm: 0,
-      book: payload.book,
-      reason: nil,
-      startedAt: payload.startDate,
-      finishedAt: payload.finishDate,
-      currentPage: payload.book.itemPage,
-      progressUpdatedAt: payload.finishDate,
-      review: trimmedReview.isEmpty ? nil : trimmedReview,
-      createdAt: now,
-      updatedAt: nil,
-      lastUpdatedAt: now
-    )
-  }
+  // MARK: - Create
   
   /// 기본 Journey(읽고 있는 책) 상태의 독서 여행을 생성합니다.
   ///
@@ -201,14 +49,11 @@ public final class ReadingJourneyService: ReadingJourneyServicing {
   ///   - 기타 Firestore 네트워크/저장 오류
   ///
   /// - Important:
-  ///   - Firestore에는 `nil` 값을 직접 저장할 수 없기 때문에
-  ///     일부 필드는 `NSNull()`로 저장됩니다.
+  ///   - Firestore에는 `nil` 값을 직접 저장할 수 없기 때문에 일부 필드는 `NSNull()`로 저장됩니다.
   public func createJourney(
     payload: JourneyPayload
   ) async throws -> ReadingJourney {
-    guard let uid = auth.currentUser?.uid else {
-      throw ReadingJourneyError.unauthenticated
-    }
+    let uid = try currentUserId()
     
     let distanceKm = Double(
       AirportInfo.distanceKm(
@@ -218,12 +63,8 @@ public final class ReadingJourneyService: ReadingJourneyServicing {
     )
     let now = Date()
     
-    let journeysRef = db
-      .collection("users")
-      .document(uid)
-      .collection("readingJourneys")
+    let journeysRef = journeysCollection(for: uid)
     
-    // 같은 노선의 wishlist / reading 중복 방지
     let duplicateSnapshot = try await journeysRef
       .whereField("departureAirport.iata", isEqualTo: payload.departureAirport.iata)
       .whereField("arrivalAirport.iata", isEqualTo: payload.destinationAirport.iata)
@@ -250,8 +91,8 @@ public final class ReadingJourneyService: ReadingJourneyServicing {
     
     let document: [String: Any] = [
       "status": ReadingJourneyStatusType.reading.rawValue,
-      "departureAirport": departureAirportDictionary(payload.departureAirport),
-      "arrivalAirport": arrivalAirportDictionary(payload.destinationAirport),
+      "departureAirport": airportDictionary(payload.departureAirport),
+      "arrivalAirport": airportDictionary(payload.destinationAirport),
       "distanceKm": distanceKm,
       "remainingDistanceKm": remainingDistanceKm,
       "book": bookDictionary(payload.book),
@@ -288,6 +129,145 @@ public final class ReadingJourneyService: ReadingJourneyServicing {
     )
   }
   
+  /// 위시리스트(읽고 싶은 책) 상태의 독서 여행을 생성합니다.
+  ///
+  /// - Parameter payload: 책, 출발지, 도착지, 이유 등을 포함한 생성 데이터
+  /// - Returns: 생성된 `ReadingJourney` 모델
+  ///
+  /// - Throws:
+  ///   - `ReadingJourneyError.unauthenticated`: 로그인된 사용자가 없는 경우
+  ///   - `ReadingJourneyError.duplicateJourney`: 동일 노선의 진행 중 여행이 이미 존재하는 경우
+  ///   - 기타 Firestore 네트워크/저장 오류
+  ///
+  /// - Important:
+  ///   - Firestore에는 `nil` 값을 직접 저장할 수 없기 때문에 일부 필드는 `NSNull()`로 저장됩니다.
+  ///   - `reason`이 비어있는 경우, 기본 문구가 랜덤으로 저장됩니다.
+  public func createWishlistJourney(
+    payload: WishlistTicketPayload
+  ) async throws -> ReadingJourney {
+    let uid = try currentUserId()
+    
+    let distanceKm = Double(
+      AirportInfo.distanceKm(from: payload.departure, to: payload.destination)
+    )
+    let now = Date()
+    
+    let journeysRef = journeysCollection(for: uid)
+    
+    let trimmedReason = payload.reason.trimmingCharacters(in: .whitespacesAndNewlines)
+    let finalReason = trimmedReason.isEmpty ? ReasonProvider.random() : trimmedReason
+    
+    let documentRef = journeysRef.document()
+    
+    let document: [String: Any] = [
+      "status": ReadingJourneyStatusType.wishlist.rawValue,
+      "departureAirport": airportDictionary(payload.departure),
+      "arrivalAirport": airportDictionary(payload.destination),
+      "distanceKm": distanceKm,
+      "remainingDistanceKm": distanceKm,
+      "book": bookDictionary(payload.book),
+      "reason": finalReason,
+      "startedAt": NSNull(),
+      "finishedAt": NSNull(),
+      "currentPage": NSNull(),
+      "progressUpdatedAt": NSNull(),
+      "review": NSNull(),
+      "createdAt": now,
+      "updatedAt": NSNull(),
+      "lastUpdatedAt": now
+    ]
+    
+    try await documentRef.setData(document)
+    
+    return ReadingJourney(
+      id: documentRef.documentID,
+      status: .wishlist,
+      departureAirport: payload.departure,
+      arrivalAirport: payload.destination,
+      distanceKm: distanceKm,
+      remainingDistanceKm: distanceKm,
+      book: payload.book,
+      reason: finalReason,
+      startedAt: nil,
+      finishedAt: nil,
+      currentPage: nil,
+      progressUpdatedAt: nil,
+      review: nil,
+      createdAt: now,
+      updatedAt: nil,
+      lastUpdatedAt: now
+    )
+  }
+  
+  /// 히스토리(다 읽은 책) 상태의 독서 여행을 생성합니다.
+  ///
+  /// - Parameter payload: 책, 출발지, 도착지, 시작일, 종료일, 감상평 등을 포함한 생성 데이터
+  /// - Returns: 생성된 `ReadingJourney` 모델
+  ///
+  /// - Throws:
+  ///   - `ReadingJourneyError.unauthenticated`: 로그인된 사용자가 없는 경우
+  ///   - `ReadingJourneyError.duplicateJourney`: 동일 노선의 진행 중 여행이 이미 존재하는 경우
+  ///   - 기타 Firestore 네트워크/저장 오류
+  ///
+  /// - Important:
+  ///   - Firestore에는 `nil` 값을 직접 저장할 수 없기 때문에 일부 필드는 `NSNull()`로 저장됩니다.
+  public func createHistoryJourney(
+    payload: HistoryPayload
+  ) async throws -> ReadingJourney {
+    let uid = try currentUserId()
+    
+    let distanceKm = Double(
+      AirportInfo.distanceKm(from: payload.departureAirport, to: payload.destinationAirport)
+    )
+    let now = Date()
+    
+    let journeysRef = journeysCollection(for: uid)
+    let documentRef = journeysRef.document()
+    
+    let trimmedReview = payload.review.trimmingCharacters(in: .whitespacesAndNewlines)
+    
+    let document: [String: Any] = [
+      "status": ReadingJourneyStatusType.finished.rawValue,
+      "departureAirport": airportDictionary(payload.departureAirport),
+      "arrivalAirport": airportDictionary(payload.destinationAirport),
+      "distanceKm": distanceKm,
+      "remainingDistanceKm": 0,
+      "book": bookDictionary(payload.book),
+      "reason": NSNull(),
+      "startedAt": payload.startDate,
+      "finishedAt": payload.finishDate,
+      "currentPage": payload.book.itemPage,
+      "progressUpdatedAt": payload.finishDate,
+      "review": trimmedReview.isEmpty ? NSNull() : trimmedReview,
+      "createdAt": now,
+      "updatedAt": NSNull(),
+      "lastUpdatedAt": now
+    ]
+    
+    try await documentRef.setData(document)
+    
+    return ReadingJourney(
+      id: documentRef.documentID,
+      status: .finished,
+      departureAirport: payload.departureAirport,
+      arrivalAirport: payload.destinationAirport,
+      distanceKm: distanceKm,
+      remainingDistanceKm: 0,
+      book: payload.book,
+      reason: nil,
+      startedAt: payload.startDate,
+      finishedAt: payload.finishDate,
+      currentPage: payload.book.itemPage,
+      progressUpdatedAt: payload.finishDate,
+      review: trimmedReview.isEmpty ? nil : trimmedReview,
+      createdAt: now,
+      updatedAt: nil,
+      lastUpdatedAt: now
+    )
+  }
+  
+  // MARK: - Update
+  
   /// 진행 중(`reading`) 독서 여행을 완료(`finished`) 상태로 변경합니다.
   ///
   /// - Parameters:
@@ -304,33 +284,13 @@ public final class ReadingJourneyService: ReadingJourneyServicing {
     journeyId: String,
     review: String
   ) async throws -> ReadingJourney {
-    guard let uid = auth.currentUser?.uid else {
-      throw ReadingJourneyError.unauthenticated
-    }
-    
-    let documentRef = db
-      .collection("users")
-      .document(uid)
-      .collection("readingJourneys")
-      .document(journeyId)
+    let uid = try currentUserId()
+    let documentRef = journeyDocumentRef(uid: uid, journeyId: journeyId)
     
     let snapshot = try await documentRef.getDocument()
+    let data = try validatedDocumentData(from: snapshot, expectedStatus: .reading)
     
-    guard let data = snapshot.data() else {
-      throw ReadingJourneyError.invalidDocument
-    }
-    
-    guard
-      let statusRaw = data["status"] as? String,
-      let status = ReadingJourneyStatusType(rawValue: statusRaw),
-      status == .reading
-    else {
-      throw ReadingJourneyError.invalidStatus
-    }
-    
-    guard
-      let bookData = data["book"] as? [String: Any]
-    else {
+    guard let bookData = data["book"] as? [String: Any] else {
       throw ReadingJourneyError.invalidDocument
     }
     
@@ -338,45 +298,48 @@ public final class ReadingJourneyService: ReadingJourneyServicing {
     let trimmedReview = review.trimmingCharacters(in: .whitespacesAndNewlines)
     let now = Date()
     
-    try await documentRef.updateData([
-      "status": ReadingJourneyStatusType.finished.rawValue,
-      "finishedAt": now,
-      "currentPage": book.itemPage,
-      "remainingDistanceKm": 0,
-      "progressUpdatedAt": now,
-      "review": trimmedReview.isEmpty ? NSNull() : trimmedReview,
-      "updatedAt": now,
-      "lastUpdatedAt": now
-    ])
-    
-    let updatedSnapshot = try await documentRef.getDocument()
-    
-    guard let updatedData = updatedSnapshot.data() else {
-      throw ReadingJourneyError.invalidDocument
-    }
-    
-    return try readingJourney(from: journeyId, data: updatedData)
+    return try await updateAndFetchJourney(
+      documentRef: documentRef,
+      journeyId: journeyId,
+      fields: [
+        "status": ReadingJourneyStatusType.finished.rawValue,
+        "finishedAt": now,
+        "currentPage": book.itemPage,
+        "remainingDistanceKm": 0,
+        "progressUpdatedAt": now,
+        "review": trimmedReview.isEmpty ? NSNull() : trimmedReview,
+        "updatedAt": now,
+        "lastUpdatedAt": now
+      ]
+    )
   }
   
+  /// 진행 중인 독서 여행의 현재 페이지를 수정합니다.
+  ///
+  /// - Parameters:
+  ///   - journeyId: 수정할 독서 여행 문서 ID
+  ///   - currentPage: 사용자가 입력한 현재 페이지
+  /// - Returns: 현재 페이지와 진행도가 반영된 `ReadingJourney`
+  ///
+  /// - Throws:
+  ///   - `ReadingJourneyError.unauthenticated`: 로그인된 사용자가 없는 경우
+  ///   - `ReadingJourneyError.invalidDocument`: 문서가 존재하지 않거나 필수 데이터가 올바르지 않은 경우
+  ///   - 기타 Firestore 조회/저장 오류
+  ///
+  /// - Important:
+  ///   - 입력된 `currentPage`는 `0...book.itemPage` 범위로 보정됩니다.
+  ///   - 진행도는 `currentPage / itemPage` 기준으로 계산됩니다.
+  ///   - 계산된 진행도에 따라 `remainingDistanceKm`가 함께 갱신됩니다.
+  ///   - 수정 시 `progressUpdatedAt`, `updatedAt`, `lastUpdatedAt`도 함께 업데이트됩니다.
   public func updateJourneyCurrentPage(
     journeyId: String,
     currentPage: Int
   ) async throws -> ReadingJourney {
-    guard let uid = auth.currentUser?.uid else {
-      throw ReadingJourneyError.unauthenticated
-    }
-    
-    let documentRef = db
-      .collection("users")
-      .document(uid)
-      .collection("readingJourneys")
-      .document(journeyId)
+    let uid = try currentUserId()
+    let documentRef = journeyDocumentRef(uid: uid, journeyId: journeyId)
     
     let snapshot = try await documentRef.getDocument()
-    
-    guard let data = snapshot.data() else {
-      throw ReadingJourneyError.invalidDocument
-    }
+    let data = try validatedDocumentData(from: snapshot)
     
     let journey = try readingJourney(from: journeyId, data: data)
     
@@ -387,105 +350,17 @@ public final class ReadingJourneyService: ReadingJourneyServicing {
     let remainingDistanceKm = max(journey.distanceKm * (1 - progress), 0)
     let now = Date()
     
-    try await documentRef.updateData([
-      "currentPage": clampedPage,
-      "remainingDistanceKm": remainingDistanceKm,
-      "progressUpdatedAt": now,
-      "updatedAt": now,
-      "lastUpdatedAt": now
-    ])
-    
-    let updatedSnapshot = try await documentRef.getDocument()
-    
-    guard let updatedData = updatedSnapshot.data() else {
-      throw ReadingJourneyError.invalidDocument
-    }
-    
-    return try readingJourney(from: journeyId, data: updatedData)
-  }
-  
-  /// 현재 사용자의 진행 중(`reading`) 독서 여행 목록을 조회합니다.
-  ///
-  /// - Returns: `reading` 상태의 `ReadingJourney` 배열
-  ///
-  /// - Throws:
-  ///   - `ReadingJourneyError.unauthenticated`: 로그인된 사용자가 없는 경우
-  ///   - Firestore 네트워크/조회 오류
-  ///
-  /// - Note:
-  ///   - 조회된 문서는 `readingJourney(from:)`를 통해 모델로 변환됩니다.
-  public func fetchReadingJourneys() async throws -> [ReadingJourney] {
-    guard let uid = auth.currentUser?.uid else {
-      throw ReadingJourneyError.unauthenticated
-    }
-    
-    let snapshot = try await db
-      .collection("users")
-      .document(uid)
-      .collection("readingJourneys")
-      .whereField("status", isEqualTo: ReadingJourneyStatusType.reading.rawValue)
-      .order(by: "lastUpdatedAt", descending: true)
-      .getDocuments()
-    
-    return try snapshot.documents.map { document in
-      try readingJourney(from: document)
-    }
-  }
-  
-  /// 현재 사용자의 진행 중(`finished`) 독서 여행 목록을 조회합니다.
-  ///
-  /// - Returns: `finished` 상태의 `ReadingJourney` 배열
-  ///
-  /// - Throws:
-  ///   - `ReadingJourneyError.unauthenticated`: 로그인된 사용자가 없는 경우
-  ///   - Firestore 네트워크/조회 오류
-  ///
-  /// - Note:
-  ///   - 조회된 문서는 `readingJourney(from:)`를 통해 모델로 변환됩니다.
-  public func fetchFinishedJourneys() async throws -> [ReadingJourney] {
-    guard let uid = auth.currentUser?.uid else {
-      throw ReadingJourneyError.unauthenticated
-    }
-    
-    let snapshot = try await db
-      .collection("users")
-      .document(uid)
-      .collection("readingJourneys")
-      .whereField("status", isEqualTo: ReadingJourneyStatusType.finished.rawValue)
-      .order(by: "finishedAt", descending: true)
-      .getDocuments()
-    
-    return try snapshot.documents.map { document in
-      try readingJourney(from: document)
-    }
-  }
-  
-  /// 현재 사용자의 위시리스트(`wishlist`) 독서 여행 목록을 조회합니다.
-  ///
-  /// - Returns: `wishlist` 상태의 `ReadingJourney` 배열
-  ///
-  /// - Throws:
-  ///   - `ReadingJourneyError.unauthenticated`: 로그인된 사용자가 없는 경우
-  ///   - Firestore 네트워크/조회 오류
-  ///
-  /// - Note:
-  ///   - 조회된 문서는 `readingJourney(from:)`를 통해 모델로 변환됩니다.
-  public func fetchWishlist() async throws -> [ReadingJourney] {
-    guard let uid = auth.currentUser?.uid else {
-      throw ReadingJourneyError.unauthenticated
-    }
-    
-    let snapshot = try await db
-      .collection("users")
-      .document(uid)
-      .collection("readingJourneys")
-      .whereField("status", isEqualTo: ReadingJourneyStatusType.wishlist.rawValue)
-      .order(by: "createdAt", descending: true)
-      .getDocuments()
-    
-    return try snapshot.documents.map { document in
-      try readingJourney(from: document)
-    }
+    return try await updateAndFetchJourney(
+      documentRef: documentRef,
+      journeyId: journeyId,
+      fields: [
+        "currentPage": clampedPage,
+        "remainingDistanceKm": remainingDistanceKm,
+        "progressUpdatedAt": now,
+        "updatedAt": now,
+        "lastUpdatedAt": now
+      ]
+    )
   }
   
   /// 위시리스트(`wishlist`) 상태의 독서 여행을 읽는 중(`reading`) 상태로 변경합니다.
@@ -501,29 +376,17 @@ public final class ReadingJourneyService: ReadingJourneyServicing {
   ///   - `ReadingJourneyError.invalidDocument`: 문서가 존재하지 않거나 필수 필드가 올바르지 않은 경우
   ///   - `ReadingJourneyError.duplicateJourney`: 동일 노선의 `reading` 상태 여행이 이미 존재하는 경우
   ///   - 기타 Firestore 네트워크/저장 오류
-  ///
-  /// - Important:
-  ///   - `wishlist` 상태의 문서만 `reading` 상태로 변경할 수 있습니다.
-  ///   - 진행도는 `currentPage / itemPage` 기준으로 계산되며,
-  ///     이에 따라 `remainingDistanceKm`도 함께 갱신됩니다.
-  ///   - 상태 변경 시 `startedAt`, `progressUpdatedAt`, `updatedAt`, `lastUpdatedAt`이 함께 업데이트됩니다.
   public func updateJourneyStatusToReading(
     journeyId: String,
     startDate: Date,
     currentPage: Int
   ) async throws -> ReadingJourney {
-    guard let uid = auth.currentUser?.uid else {
-      throw ReadingJourneyError.unauthenticated
-    }
+    let uid = try currentUserId()
     
-    let journeysRef = db
-      .collection("users")
-      .document(uid)
-      .collection("readingJourneys")
-    
+    let journeysRef = journeysCollection(for: uid)
     let documentRef = journeysRef.document(journeyId)
-    let snapshot = try await documentRef.getDocument()
     
+    let snapshot = try await documentRef.getDocument()
     guard let data = snapshot.data() else {
       throw ReadingJourneyError.invalidDocument
     }
@@ -563,148 +426,19 @@ public final class ReadingJourneyService: ReadingJourneyServicing {
     let remainingDistanceKm = max(distanceKm * (1 - progress), 0)
     let now = Date()
     
-    try await documentRef.updateData([
-      "status": ReadingJourneyStatusType.reading.rawValue,
-      "startedAt": startDate,
-      "currentPage": currentPage,
-      "progressUpdatedAt": now,
-      "remainingDistanceKm": remainingDistanceKm,
-      "updatedAt": now,
-      "lastUpdatedAt": now
-    ])
-    
-    let updatedSnapshot = try await documentRef.getDocument()
-    
-    guard let updatedData = updatedSnapshot.data() else {
-      throw ReadingJourneyError.invalidDocument
-    }
-    
-    return try readingJourney(from: journeyId, data: updatedData)
-  }
-  
-  /// 진행 중(`reading`) 상태의 독서 여행을 삭제합니다.
-  ///
-  /// - Parameter journeyId: 삭제할 독서 여행 문서 ID
-  ///
-  /// - Throws:
-  ///   - `ReadingJourneyError.unauthenticated`: 로그인된 사용자가 없는 경우
-  ///   - `ReadingJourneyError.invalidDocument`: 문서가 존재하지 않거나 데이터를 읽을 수 없는 경우
-  ///   - `ReadingJourneyError.invalidStatus`: 삭제 대상이 `reading` 상태가 아닌 경우
-  ///   - 기타 Firestore 네트워크/삭제 오류
-  ///
-  /// - Important:
-  ///   - `reading` 상태의 문서만 삭제할 수 있습니다.
-  ///   - `wishlist`, `finished` 상태의 여행은 이 메서드로 삭제되지 않습니다.
-  public func deleteReadingJourney(
-    journeyId: String
-  ) async throws {
-    guard let uid = auth.currentUser?.uid else {
-      throw ReadingJourneyError.unauthenticated
-    }
-    
-    let documentRef = db
-      .collection("users")
-      .document(uid)
-      .collection("readingJourneys")
-      .document(journeyId)
-    
-    let snapshot = try await documentRef.getDocument()
-    
-    guard let data = snapshot.data() else {
-      throw ReadingJourneyError.invalidDocument
-    }
-    
-    guard
-      let statusRaw = data["status"] as? String,
-      let status = ReadingJourneyStatusType(rawValue: statusRaw),
-      status == .reading
-    else {
-      throw ReadingJourneyError.invalidStatus
-    }
-    
-    try await documentRef.delete()
-  }
-  
-  /// 위시리스트(`wishlist`) 상태의 독서 여행을 삭제합니다.
-  ///
-  /// - Parameter journeyId: 삭제할 독서 여행 문서 ID
-  ///
-  /// - Throws:
-  ///   - `ReadingJourneyError.unauthenticated`: 로그인된 사용자가 없는 경우
-  ///   - `ReadingJourneyError.invalidDocument`: 문서가 존재하지 않거나 데이터를 읽을 수 없는 경우
-  ///   - `ReadingJourneyError.invalidStatus`: 삭제 대상이 `wishlist` 상태가 아닌 경우
-  ///   - 기타 Firestore 네트워크/삭제 오류
-  ///
-  /// - Important:
-  ///   - `wishlist` 상태의 문서만 삭제할 수 있습니다.
-  ///   - `reading`, `finished` 상태의 여행은 이 메서드로 삭제되지 않습니다.
-  public func deleteWishlistJourney(
-    journeyId: String
-  ) async throws {
-    guard let uid = auth.currentUser?.uid else {
-      throw ReadingJourneyError.unauthenticated
-    }
-    
-    let documentRef = db
-      .collection("users")
-      .document(uid)
-      .collection("readingJourneys")
-      .document(journeyId)
-    
-    let snapshot = try await documentRef.getDocument()
-    
-    guard let data = snapshot.data() else {
-      throw ReadingJourneyError.invalidDocument
-    }
-    
-    guard
-      let statusRaw = data["status"] as? String,
-      let status = ReadingJourneyStatusType(rawValue: statusRaw),
-      status == .wishlist
-    else {
-      throw ReadingJourneyError.invalidStatus
-    }
-    
-    try await documentRef.delete()
-  }
-  
-  /// 히스토리(`finished`) 상태의 독서 여행을 삭제합니다.
-  ///
-  /// - Parameter journeyId: 삭제할 독서 여행 문서 ID
-  ///
-  /// - Throws:
-  ///   - `ReadingJourneyError.unauthenticated`: 로그인된 사용자가 없는 경우
-  ///   - `ReadingJourneyError.invalidDocument`: 문서가 존재하지 않거나 데이터를 읽을 수 없는 경우
-  ///   - `ReadingJourneyError.invalidStatus`: 삭제 대상이 `finished` 상태가 아닌 경우
-  ///   - 기타 Firestore 네트워크/삭제 오류
-  public func deleteFinishedJourney(
-    journeyId: String
-  ) async throws {
-    guard let uid = auth.currentUser?.uid else {
-      throw ReadingJourneyError.unauthenticated
-    }
-    
-    let documentRef = db
-      .collection("users")
-      .document(uid)
-      .collection("readingJourneys")
-      .document(journeyId)
-    
-    let snapshot = try await documentRef.getDocument()
-    
-    guard let data = snapshot.data() else {
-      throw ReadingJourneyError.invalidDocument
-    }
-    
-    guard
-      let statusRaw = data["status"] as? String,
-      let status = ReadingJourneyStatusType(rawValue: statusRaw),
-      status == .finished
-    else {
-      throw ReadingJourneyError.invalidStatus
-    }
-    
-    try await documentRef.delete()
+    return try await updateAndFetchJourney(
+      documentRef: documentRef,
+      journeyId: journeyId,
+      fields: [
+        "status": ReadingJourneyStatusType.reading.rawValue,
+        "startedAt": startDate,
+        "currentPage": currentPage,
+        "progressUpdatedAt": now,
+        "remainingDistanceKm": remainingDistanceKm,
+        "updatedAt": now,
+        "lastUpdatedAt": now
+      ]
+    )
   }
   
   /// 히스토리(`finished`) 상태의 독서 여행 날짜를 수정합니다.
@@ -720,61 +454,35 @@ public final class ReadingJourneyService: ReadingJourneyServicing {
   ///   - `ReadingJourneyError.invalidDocument`: 문서가 존재하지 않거나 필수 데이터가 올바르지 않은 경우
   ///   - `ReadingJourneyError.invalidStatus`: 수정 대상이 `finished` 상태가 아닌 경우
   ///   - 기타 Firestore 네트워크/저장 오류
-  ///
-  /// - Important:
-  ///   - `finished` 상태의 문서만 수정할 수 있습니다.
-  ///   - `startDate`는 `finishDate`보다 늦을 수 없습니다.
-  ///   - 날짜 수정 시 `progressUpdatedAt`, `updatedAt`, `lastUpdatedAt`도 함께 갱신됩니다.
   public func updateFinishedJourneyDates(
     journeyId: String,
     startDate: Date,
     finishDate: Date
   ) async throws -> ReadingJourney {
-    guard let uid = auth.currentUser?.uid else {
-      throw ReadingJourneyError.unauthenticated
-    }
+    let uid = try currentUserId()
     
     guard startDate <= finishDate else {
       throw ReadingJourneyError.invalidDocument
     }
     
-    let documentRef = db
-      .collection("users")
-      .document(uid)
-      .collection("readingJourneys")
-      .document(journeyId)
+    let documentRef = journeyDocumentRef(uid: uid, journeyId: journeyId)
     
     let snapshot = try await documentRef.getDocument()
-    
-    guard let data = snapshot.data() else {
-      throw ReadingJourneyError.invalidDocument
-    }
-    
-    guard
-      let statusRaw = data["status"] as? String,
-      let status = ReadingJourneyStatusType(rawValue: statusRaw),
-      status == .finished
-    else {
-      throw ReadingJourneyError.invalidStatus
-    }
+    _ = try validatedDocumentData(from: snapshot, expectedStatus: .finished)
     
     let now = Date()
     
-    try await documentRef.updateData([
-      "startedAt": startDate,
-      "finishedAt": finishDate,
-      "progressUpdatedAt": finishDate,
-      "updatedAt": now,
-      "lastUpdatedAt": now
-    ])
-    
-    let updatedSnapshot = try await documentRef.getDocument()
-    
-    guard let updatedData = updatedSnapshot.data() else {
-      throw ReadingJourneyError.invalidDocument
-    }
-    
-    return try readingJourney(from: journeyId, data: updatedData)
+    return try await updateAndFetchJourney(
+      documentRef: documentRef,
+      journeyId: journeyId,
+      fields: [
+        "startedAt": startDate,
+        "finishedAt": finishDate,
+        "progressUpdatedAt": finishDate,
+        "updatedAt": now,
+        "lastUpdatedAt": now
+      ]
+    )
   }
   
   /// 히스토리(`finished`) 상태의 독서 여행 감상평을 수정합니다.
@@ -793,53 +501,202 @@ public final class ReadingJourneyService: ReadingJourneyServicing {
     journeyId: String,
     review: String
   ) async throws -> ReadingJourney {
-    guard let uid = auth.currentUser?.uid else {
-      throw ReadingJourneyError.unauthenticated
-    }
-    
-    let documentRef = db
-      .collection("users")
-      .document(uid)
-      .collection("readingJourneys")
-      .document(journeyId)
+    let uid = try currentUserId()
+    let documentRef = journeyDocumentRef(uid: uid, journeyId: journeyId)
     
     let snapshot = try await documentRef.getDocument()
-    
-    guard let data = snapshot.data() else {
-      throw ReadingJourneyError.invalidDocument
-    }
-    
-    guard
-      let statusRaw = data["status"] as? String,
-      let status = ReadingJourneyStatusType(rawValue: statusRaw),
-      status == .finished
-    else {
-      throw ReadingJourneyError.invalidStatus
-    }
+    _ = try validatedDocumentData(from: snapshot, expectedStatus: .finished)
     
     let trimmedReview = review.trimmingCharacters(in: .whitespacesAndNewlines)
     let now = Date()
     
-    try await documentRef.updateData([
-      "review": trimmedReview.isEmpty ? NSNull() : trimmedReview,
-      "updatedAt": now,
-      "lastUpdatedAt": now
-    ])
+    return try await updateAndFetchJourney(
+      documentRef: documentRef,
+      journeyId: journeyId,
+      fields: [
+        "review": trimmedReview.isEmpty ? NSNull() : trimmedReview,
+        "updatedAt": now,
+        "lastUpdatedAt": now
+      ]
+    )
+  }
+  
+  // MARK: - Read
+  
+  /// 현재 사용자의 진행 중(`reading`) 독서 여행 목록을 조회합니다.
+  ///
+  /// - Returns: `reading` 상태의 `ReadingJourney` 배열
+  ///
+  /// - Throws:
+  ///   - `ReadingJourneyError.unauthenticated`: 로그인된 사용자가 없는 경우
+  ///   - Firestore 네트워크/조회 오류
+  public func fetchReadingJourneys() async throws -> [ReadingJourney] {
+    let uid = try currentUserId()
+    
+    let snapshot = try await journeysCollection(for: uid)
+      .whereField("status", isEqualTo: ReadingJourneyStatusType.reading.rawValue)
+      .order(by: "lastUpdatedAt", descending: true)
+      .getDocuments()
+    
+    return try snapshot.documents.map(readingJourney(from:))
+  }
+  
+  /// 현재 사용자의 위시리스트(`wishlist`) 독서 여행 목록을 조회합니다.
+  ///
+  /// - Returns: `wishlist` 상태의 `ReadingJourney` 배열
+  ///
+  /// - Throws:
+  ///   - `ReadingJourneyError.unauthenticated`: 로그인된 사용자가 없는 경우
+  ///   - Firestore 네트워크/조회 오류
+  public func fetchWishlist() async throws -> [ReadingJourney] {
+    let uid = try currentUserId()
+    
+    let snapshot = try await journeysCollection(for: uid)
+      .whereField("status", isEqualTo: ReadingJourneyStatusType.wishlist.rawValue)
+      .order(by: "createdAt", descending: true)
+      .getDocuments()
+    
+    return try snapshot.documents.map(readingJourney(from:))
+  }
+  
+  /// 현재 사용자의 완료(`finished`) 독서 여행 목록을 조회합니다.
+  ///
+  /// - Returns: `finished` 상태의 `ReadingJourney` 배열
+  ///
+  /// - Throws:
+  ///   - `ReadingJourneyError.unauthenticated`: 로그인된 사용자가 없는 경우
+  ///   - Firestore 네트워크/조회 오류
+  public func fetchFinishedJourneys() async throws -> [ReadingJourney] {
+    let uid = try currentUserId()
+    
+    let snapshot = try await journeysCollection(for: uid)
+      .whereField("status", isEqualTo: ReadingJourneyStatusType.finished.rawValue)
+      .order(by: "finishedAt", descending: true)
+      .getDocuments()
+    
+    return try snapshot.documents.map(readingJourney(from:))
+  }
+  
+  // MARK: - Delete
+  
+  /// 진행 중(`reading`) 상태의 독서 여행을 삭제합니다.
+  ///
+  /// - Parameter journeyId: 삭제할 독서 여행 문서 ID
+  ///
+  /// - Throws:
+  ///   - `ReadingJourneyError.unauthenticated`: 로그인된 사용자가 없는 경우
+  ///   - `ReadingJourneyError.invalidDocument`: 문서가 존재하지 않거나 데이터를 읽을 수 없는 경우
+  ///   - `ReadingJourneyError.invalidStatus`: 삭제 대상이 `reading` 상태가 아닌 경우
+  ///   - 기타 Firestore 네트워크/삭제 오류
+  public func deleteReadingJourney(
+    journeyId: String
+  ) async throws {
+    try await deleteJourney(journeyId: journeyId, expectedStatus: .reading)
+  }
+  
+  /// 위시리스트(`wishlist`) 상태의 독서 여행을 삭제합니다.
+  ///
+  /// - Parameter journeyId: 삭제할 독서 여행 문서 ID
+  ///
+  /// - Throws:
+  ///   - `ReadingJourneyError.unauthenticated`: 로그인된 사용자가 없는 경우
+  ///   - `ReadingJourneyError.invalidDocument`: 문서가 존재하지 않거나 데이터를 읽을 수 없는 경우
+  ///   - `ReadingJourneyError.invalidStatus`: 삭제 대상이 `wishlist` 상태가 아닌 경우
+  ///   - 기타 Firestore 네트워크/삭제 오류
+  public func deleteWishlistJourney(
+    journeyId: String
+  ) async throws {
+    try await deleteJourney(journeyId: journeyId, expectedStatus: .wishlist)
+  }
+  
+  /// 히스토리(`finished`) 상태의 독서 여행을 삭제합니다.
+  ///
+  /// - Parameter journeyId: 삭제할 독서 여행 문서 ID
+  ///
+  /// - Throws:
+  ///   - `ReadingJourneyError.unauthenticated`: 로그인된 사용자가 없는 경우
+  ///   - `ReadingJourneyError.invalidDocument`: 문서가 존재하지 않거나 데이터를 읽을 수 없는 경우
+  ///   - `ReadingJourneyError.invalidStatus`: 삭제 대상이 `finished` 상태가 아닌 경우
+  ///   - 기타 Firestore 네트워크/삭제 오류
+  public func deleteFinishedJourney(
+    journeyId: String
+  ) async throws {
+    try await deleteJourney(journeyId: journeyId, expectedStatus: .finished)
+  }
+}
+
+// MARK: - Helper
+private extension ReadingJourneyService {
+  func currentUserId() throws -> String {
+    guard let uid = auth.currentUser?.uid else {
+      throw ReadingJourneyError.unauthenticated
+    }
+    return uid
+  }
+  
+  func journeysCollection(for uid: String) -> CollectionReference {
+    db.collection("users")
+      .document(uid)
+      .collection("readingJourneys")
+  }
+  
+  func journeyDocumentRef(
+    uid: String,
+    journeyId: String
+  ) -> DocumentReference {
+    journeysCollection(for: uid).document(journeyId)
+  }
+  
+  func validatedDocumentData(
+    from snapshot: DocumentSnapshot,
+    expectedStatus: ReadingJourneyStatusType? = nil
+  ) throws -> [String: Any] {
+    guard let data = snapshot.data() else {
+      throw ReadingJourneyError.invalidDocument
+    }
+    
+    if let expectedStatus {
+      guard
+        let statusRaw = data["status"] as? String,
+        let status = ReadingJourneyStatusType(rawValue: statusRaw),
+        status == expectedStatus
+      else {
+        throw ReadingJourneyError.invalidStatus
+      }
+    }
+    
+    return data
+  }
+  
+  func updateAndFetchJourney(
+    documentRef: DocumentReference,
+    journeyId: String,
+    fields: [AnyHashable: Any]
+  ) async throws -> ReadingJourney {
+    try await documentRef.updateData(fields)
     
     let updatedSnapshot = try await documentRef.getDocument()
-    
     guard let updatedData = updatedSnapshot.data() else {
       throw ReadingJourneyError.invalidDocument
     }
     
     return try readingJourney(from: journeyId, data: updatedData)
   }
-}
-
-// MARK: - Helper
-private extension ReadingJourneyService {
-  // AirportInfo를 Firestore 저장용 딕셔너리로 변환
-  func departureAirportDictionary(_ airport: AirportInfo) -> [String: Any] {
+  
+  func deleteJourney(
+    journeyId: String,
+    expectedStatus: ReadingJourneyStatusType
+  ) async throws {
+    let uid = try currentUserId()
+    let documentRef = journeyDocumentRef(uid: uid, journeyId: journeyId)
+    
+    let snapshot = try await documentRef.getDocument()
+    _ = try validatedDocumentData(from: snapshot, expectedStatus: expectedStatus)
+    
+    try await documentRef.delete()
+  }
+  
+  func airportDictionary(_ airport: AirportInfo) -> [String: Any] {
     [
       "iata": airport.iata,
       "airportNameEn": airport.airportNameEn,
@@ -853,22 +710,6 @@ private extension ReadingJourneyService {
     ]
   }
   
-  // AirportInfo를 Firestore 저장용 딕셔너리로 변환
-  func arrivalAirportDictionary(_ airport: AirportInfo) -> [String: Any] {
-    [
-      "iata": airport.iata,
-      "airportNameEn": airport.airportNameEn,
-      "airportNameKo": airport.airportNameKo,
-      "cityNameEn": airport.cityNameEn,
-      "cityNameKo": airport.cityNameKo,
-      "countryNameKo": airport.countryNameKo,
-      "latitude": airport.latitude,
-      "longitude": airport.longitude,
-      "searchText": airport.searchText
-    ]
-  }
-  
-  // BookInfo를 Firestore 저장용 딕셔너리로 변환
   func bookDictionary(_ book: BookInfo) -> [String: Any] {
     [
       "isbn13": book.isbn13,
@@ -881,61 +722,10 @@ private extension ReadingJourneyService {
     ]
   }
   
-  /// Firestore 문서를 ReadingJourney 모델로 변환합니다.
-  ///
-  /// - Parameter document: Firestore에서 조회한 문서
-  /// - Returns: 변환된 ReadingJourney 모델
-  /// - Throws: 필수 필드가 없거나 타입이 맞지 않는 경우 `invalidDocument` 오류 발생
   func readingJourney(
     from document: QueryDocumentSnapshot
   ) throws -> ReadingJourney {
-    let data = document.data()
-    
-    guard
-      let statusRawValue = data["status"] as? String,
-      let status = ReadingJourneyStatusType(rawValue: statusRawValue),
-      let departureAirportData = data["departureAirport"] as? [String: Any],
-      let arrivalAirportData = data["arrivalAirport"] as? [String: Any],
-      let distanceKm = data["distanceKm"] as? Double,
-      let bookData = data["book"] as? [String: Any],
-      let createdAtTimestamp = data["createdAt"] as? Timestamp,
-      let lastUpdatedAtTimestamp = data["lastUpdatedAt"] as? Timestamp
-    else {
-      throw ReadingJourneyError.invalidDocument
-    }
-    
-    let departureAirport = try airportInfo(from: departureAirportData)
-    let arrivalAirport = try airportInfo(from: arrivalAirportData)
-    let book = try bookInfo(from: bookData)
-    
-    let remainingDistanceKm = data["remainingDistanceKm"] as? Double
-    let reason = data["reason"] as? String
-    let currentPage = data["currentPage"] as? Int
-    let review = data["review"] as? String
-    
-    let startedAt = (data["startedAt"] as? Timestamp)?.dateValue()
-    let finishedAt = (data["finishedAt"] as? Timestamp)?.dateValue()
-    let progressUpdatedAt = (data["progressUpdatedAt"] as? Timestamp)?.dateValue()
-    let updatedAt = (data["updatedAt"] as? Timestamp)?.dateValue()
-    
-    return ReadingJourney(
-      id: document.documentID,
-      status: status,
-      departureAirport: departureAirport,
-      arrivalAirport: arrivalAirport,
-      distanceKm: distanceKm,
-      remainingDistanceKm: remainingDistanceKm,
-      book: book,
-      reason: reason,
-      startedAt: startedAt,
-      finishedAt: finishedAt,
-      currentPage: currentPage,
-      progressUpdatedAt: progressUpdatedAt,
-      review: review,
-      createdAt: createdAtTimestamp.dateValue(),
-      updatedAt: updatedAt,
-      lastUpdatedAt: lastUpdatedAtTimestamp.dateValue()
-    )
+    try readingJourney(from: document.documentID, data: document.data())
   }
   
   func readingJourney(
@@ -989,9 +779,6 @@ private extension ReadingJourneyService {
     )
   }
   
-  /// Firestore 딕셔너리를 AirportInfo 모델로 변환합니다.
-  ///
-  /// - Throws: 필수 필드 누락 시 `invalidDocument`
   func airportInfo(from data: [String: Any]) throws -> AirportInfo {
     guard
       let iata = data["iata"] as? String,
@@ -1020,9 +807,6 @@ private extension ReadingJourneyService {
     )
   }
   
-  /// Firestore 딕셔너리를 BookInfo 모델로 변환합니다.
-  ///
-  /// - Throws: 필수 필드 누락 시 `invalidDocument`
   func bookInfo(from data: [String: Any]) throws -> BookInfo {
     guard
       let isbn13 = data["isbn13"] as? String,
@@ -1047,4 +831,3 @@ private extension ReadingJourneyService {
     )
   }
 }
-


### PR DESCRIPTION
## 관련 이슈 (Related Issue)

<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->

- Closes #92 

---

## 작업 내용

<!-- 무엇을 변경했는지 간단히 설명 -->

- 중복되는 코드 Helper 함수로 분리하여 중복 최소화

---

## 변경 사항

<!-- 주요 변경 사항을 작성 -->

- 헬퍼 메소드 구현

---

## 스크린샷 / 영상 (UI 변경 시)

---

## 테스트

- [x] 로컬 빌드 확인
- [ ] 시뮬레이터 실행
- [ ] 테스트 코드 통과
- [ ] CI 통과

---

## 영향 범위

- [ ] App
- [ ] Core
- [ ] DesignSystem
- [ ] Feature
- [x] Service
- [ ] Tuist
- [ ] CI / Fastlane

---

## 리뷰 포인트

<!-- 리뷰어가 집중해서 보면 좋은 부분 -->

### 1. History, Journey, Wishlist를 별도 서비스로 분리하지 않고 단일 서비스로 유지한 이유
- History, Journey, Wishlist는 서로 완전히 다른 도메인이 아니라, 동일한 ReadingJourney 엔티티를 상태(finished, reading, wishlist) 기준으로 다루는 구조라고 판단했습니다.
- 세 서비스를 분리할 경우 Firestore 경로 접근, 사용자 uid 조회, 문서 파싱, 상태 검증 등의 공통 로직이 각 서비스에 다시 중복될 가능성이 높아 우선 단일 ReadingJourneyService 내에서 공통 로직을 정리하는 방향을 선택했습니다.
- 현재 단계에서는 서비스 분리보다 중복 제거와 가독성 개선의 효과가 더 크다고 판단했습니다.

### 2. 어떤 코드를 어떤 Helper 메소드로 분리했는지
1. 로그인 사용자 확인 로직
- currentUserId()
- 각 메서드에서 반복되던 auth.currentUser?.uid 검증 코드를 공통화했습니다.

2. readingJourneys 컬렉션 / 문서 경로 생성 로직
- Firestore 경로 체인(users/{uid}/readingJourneys/...)이 여러 메서드에서 반복되어 이를 헬퍼로 분리했습니다.

3. 문서 유효성 및 상태 검증 로직
- DocumentSnapshot의 데이터 존재 여부 확인과 상태(reading, wishlist, finished) 검증 로직을 공통화했습니다.

4. 업데이트 후 재조회 및 모델 변환 로직
- updateData 이후 다시 문서를 조회하고 ReadingJourney로 변환하는 반복 패턴을 헬퍼로 분리했습니다.

5. 삭제 전 상태 검증 및 삭제 로직
- 상태 검증 후 문서를 삭제하는 공통 흐름을 하나의 헬퍼로 정리했습니다.

6. 공항 딕셔너리 변환 로직
- 기존 departureAirportDictionary, arrivalAirportDictionary로 나뉘어 있던 동일 로직을 하나로 통합했습니다.

7. Firestore 문서 → 모델 변환 로직
- 문서 스냅샷과 딕셔너리 데이터를 ReadingJourney로 변환하는 로직을 한 곳으로 모아 중복을 줄였습니다.

---

## 레퍼런스

<!-- 참고했던 레퍼런스 등 -->

-

---

## 체크리스트

- [x] 불필요한 코드 제거
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트
- [ ] CI 통과