### PR TITLE
refactor:#96 TooltipService를 Builder에서 제거하고 외부 주입으로 변경

### DIFF
--- a/Features/Journey/JourneyFeature/Sources/Builders/JourneyBuilder.swift
+++ b/Features/Journey/JourneyFeature/Sources/Builders/JourneyBuilder.swift
@@ -8,18 +8,22 @@
 import Core
 import UIKit
 import JourneyInterface
-import TooltipImplementation
+import TooltipInterface
 import ReadingJourneyImplementation
 
 public final class JourneyBuilder: JourneyBuildable {
-  public init() {}
+  private let tooltipService: TooltipServicing
+  public init(
+    tooltipService: TooltipServicing
+  ) {
+    self.tooltipService = tooltipService
+  }
   
   public func build(
     onRoute: ((JourneyRoute) -> Void)?
   ) -> UIViewController {
     let readingJourneyService = ReadingJourneyService()
     let memoService = JourneyMemoService()
-    let tooltipService = TooltipService()
     let viewModel = JourneyViewModel(
       readingJourneyService: readingJourneyService,
       memoService: memoService,

--- a/Features/Wishlist/WishlistFeature/Sources/Builders/WishlistBuilder.swift
+++ b/Features/Wishlist/WishlistFeature/Sources/Builders/WishlistBuilder.swift
@@ -8,17 +8,23 @@
 import Core
 import UIKit
 import WishlistInterface
-import TooltipImplementation
+import TooltipInterface
 import ReadingJourneyImplementation
 
 public final class WishlistBuilder: WishlistBuildable {
-  public init() {}
+  let tooltipService: TooltipServicing
+  
+  public init(
+    tooltipService: TooltipServicing
+  ) {
+    self.tooltipService = tooltipService
+  }
   
   public func build(
     onRoute: @escaping (WishlistRoute) -> Void
   ) -> UIViewController {
     let readingJourneyService = ReadingJourneyService()
-    let tooltipService = TooltipService()
+    let tooltipService = tooltipService
     let viewModel = WishlistViewModel(
       readingJourneyService: readingJourneyService,
       tooltipService: tooltipService

--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -14,6 +14,7 @@ import SearchFeature
 import WishlistFeature
 import HistoryFeature
 import JourneyFeature
+import TooltipImplementation
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   
@@ -36,18 +37,26 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     let navigationController = UINavigationController()
     navigationController.navigationBar.isHidden = true
     
+    // MARK: - Service
     let authService = AuthService()
+    let tooltipService = TooltipService()
+    // MARK: - Builder
+
     let homeBuilder = HomeBuilder()
     let loginBuilder = LoginBuilder()
     let searchBuilder = SearchBuilder()
-    let wishlistBuilder = WishlistBuilder()
+    let wishlistBuilder = WishlistBuilder(
+      tooltipService: tooltipService
+    )
     let registerWishlistBuilder = RegisterWishlistBuilder()
     let wishTicketBuilder = WishTicketBuilder()
     let checkInWishTicketBuilder = CheckInWishTicketBuilder()
     let registerHistoryBuilder = RegisterHistoryBuilder()
     let registerJourneyBuilder = RegisterJourneyBuilder()
     let journeyTicketBuilder = JourneyTicketBuilder()
-    let journeyBuilder = JourneyBuilder()
+    let journeyBuilder = JourneyBuilder(
+      tooltipService: tooltipService
+    )
     let historyBuilder = HistoryBuilder()
     let detailHistoryBuilder = DetailHistoryBuilder()
     


### PR DESCRIPTION
## 관련 이슈 (Related Issue)

<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->

- #96 

---

## 작업 내용

<!-- 무엇을 변경했는지 간단히 설명 -->

- TooltipService의 생성 위치를 Builder에서 App 레이어로 이동하고, 생성자 주입 방식으로 수정

---

## 변경 사항

<!-- 주요 변경 사항을 작성 -->

- JourneyBuilder 내부에서 TooltipService 직접 생성 로직 제거
- WishlistBuilder 내부에서 TooltipService 직접 생성 로직 제거
- SceneDelegate에서 TooltipService 생성 후 JourneyBuilder에 주입
- TooltipImplementation 의존 제거 → TooltipInterface 의존으로 변경

---

## 스크린샷 / 영상 (UI 변경 시)

---

## 테스트

- [x] 로컬 빌드 확인
- [ ] 시뮬레이터 실행
- [ ] 테스트 코드 통과
- [ ] CI 통과

---

## 영향 범위

- [x] App
- [ ] Core
- [ ] DesignSystem
- [x] Feature
- [ ] Tuist
- [ ] CI / Fastlane

---

## 리뷰 포인트

<!-- 리뷰어가 집중해서 보면 좋은 부분 -->

### 수정 전
<img width="500" height="320" alt="스크린샷 2026-04-14 오후 7 55 14" src="https://github.com/user-attachments/assets/66c32464-78c7-459c-96b8-eefa37834964" /> <br>
- 빌더가 직접 서비스 구현체를 생성
- App은 빌더만 생성
- 빌더가 구현체를 직접 의존하는 구조

### 수정 후
<img width="500" height="320" alt="스크린샷 2026-04-14 오후 7 55 46" src="https://github.com/user-attachments/assets/cefd75ac-1002-4867-add2-562a53835c62" /> <br>
- App이 구현체 생성
- 빌더는 인터페이스만 의존
- DI 흐름 명확해짐( 앱 -> 빌더 -> 뷰모델 -> 서비스(구현체) )

---

## 레퍼런스

<!-- 참고했던 레퍼런스 등 -->

---

## 체크리스트

- [x] 불필요한 코드 제거
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트
- [ ] CI 통과