### PR TITLE
refactor:#96 SearchHistoryService를 Builder에서 제거하고 외부 주입으로 변경

### DIFF
--- a/Features/Search/SearchFeature/Sources/Builders/SearchBuilder.swift
+++ b/Features/Search/SearchFeature/Sources/Builders/SearchBuilder.swift
@@ -11,11 +11,17 @@ import AirportSearchImplementation
 import BookSearchInterface
 import BookSearchImplementation
 import SearchInterface
-import SearchHistoryImplementation
+import SearchHistoryInterface
 import UIKit
 
 public final class SearchBuilder: SearchBuildable {
-  public init() {}
+  let searchHistoryService: SearchHistoryServicing
+  
+  public init(
+    searchHistoryService: SearchHistoryServicing
+  ) {
+    self.searchHistoryService = searchHistoryService
+  }
 
   public func build(
     type: SearchType,
@@ -25,8 +31,6 @@ public final class SearchBuilder: SearchBuildable {
     let airportSearchService = AirportSearchService(
       bundle: Bundle(for: AirportSearchService.self)
     )
-    let searchHistoryService = SearchHistoryService()
-
     try? airportSearchService.loadAirports()
     
     let viewModel = SearchViewModel(

--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -15,6 +15,7 @@ import WishlistFeature
 import HistoryFeature
 import JourneyFeature
 import TooltipImplementation
+import SearchHistoryImplementation
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   
@@ -40,11 +41,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // MARK: - Service
     let authService = AuthService()
     let tooltipService = TooltipService()
+    let searchHistoryService = SearchHistoryService()
+    
     // MARK: - Builder
-
     let homeBuilder = HomeBuilder()
     let loginBuilder = LoginBuilder()
-    let searchBuilder = SearchBuilder()
+    let searchBuilder = SearchBuilder(
+      searchHistoryService: searchHistoryService
+    )
     let wishlistBuilder = WishlistBuilder(
       tooltipService: tooltipService
     )


### PR DESCRIPTION
## 관련 이슈 (Related Issue)

<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->

- #96 

---

## 작업 내용

<!-- 무엇을 변경했는지 간단히 설명 -->

- SearchHistoryService의 생성 위치를 Builder에서 App 레이어로 이동하고, 생성자 주입 방식으로 수정

---

## 변경 사항

<!-- 주요 변경 사항을 작성 -->

-SearchBuilder 내부에서 SearchHistoryService 직접 생성 로직 제거

---

## 스크린샷 / 영상 (UI 변경 시)

---

## 테스트

- [x] 로컬 빌드 확인
- [ ] 시뮬레이터 실행
- [ ] 테스트 코드 통과
- [ ] CI 통과

---

## 영향 범위

- [x] App
- [ ] Core
- [ ] DesignSystem
- [x] Feature
- [ ] Tuist
- [ ] CI / Fastlane

---

## 리뷰 포인트

<!-- 리뷰어가 집중해서 보면 좋은 부분 -->

### 수정 전
<img width="500" height="320" alt="스크린샷 2026-04-14 오후 8 10 07" src="https://github.com/user-attachments/assets/4d3e1cef-31d6-46b9-bae5-934d62463a8e" /> <br>
- 빌더가 직접 서비스 구현체를 생성
- App은 빌더만 생성
- 빌더가 구현체를 직접 의존하는 구조

### 수정 후
<img width="500" height="320" alt="스크린샷 2026-04-14 오후 8 12 47" src="https://github.com/user-attachments/assets/b3fde8a6-2a13-4c04-add5-771f475578ab" /> <br>
- App이 구현체 생성
- 빌더는 인터페이스만 의존
- DI 흐름 명확해짐( 앱 -> 빌더 -> 뷰모델 -> 서비스(구현체) )

---

## 레퍼런스

<!-- 참고했던 레퍼런스 등 -->

---

## 체크리스트

- [x] 불필요한 코드 제거
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트
- [ ] CI 통과