### PR TITLE
refactor:#96 AirportSearchService를 Builder에서 제거하고 외부 주입으로 변경

### DIFF
--- a/Features/Search/SearchFeature/Sources/Builders/SearchBuilder.swift
+++ b/Features/Search/SearchFeature/Sources/Builders/SearchBuilder.swift
@@ -7,20 +7,22 @@
 
 import Core
 import AirportSearchInterface
-import AirportSearchImplementation
 import BookSearchInterface
 import SearchInterface
 import SearchHistoryInterface
 import UIKit
 
 public final class SearchBuilder: SearchBuildable {
+  let airportSearchService: AirportSearchServicing
   let bookSearchService: BookSearchServicing
   let searchHistoryService: SearchHistoryServicing
   
   public init(
+    airportSearchService: AirportSearchServicing,
     bookSearchService: BookSearchServicing,
     searchHistoryService: SearchHistoryServicing
   ) {
+    self.airportSearchService = airportSearchService
     self.bookSearchService = bookSearchService
     self.searchHistoryService = searchHistoryService
   }
@@ -29,11 +31,6 @@ public final class SearchBuilder: SearchBuildable {
     type: SearchType,
     onRoute: @escaping (SearchRoute) -> Void
   ) -> UIViewController {
-    let airportSearchService = AirportSearchService(
-      bundle: Bundle(for: AirportSearchService.self)
-    )
-    try? airportSearchService.loadAirports()
-    
     let viewModel = SearchViewModel(
       type: type,
       bookSearchService: bookSearchService,

--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -14,9 +14,10 @@ import SearchFeature
 import WishlistFeature
 import HistoryFeature
 import JourneyFeature
-import TooltipImplementation
+import AirportSearchImplementation
 import BookSearchImplementation
 import SearchHistoryImplementation
+import TooltipImplementation
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   
@@ -40,15 +41,22 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     navigationController.navigationBar.isHidden = true
     
     // MARK: - Service
+    let airportSearchService = AirportSearchService(
+      bundle: Bundle(for: AirportSearchService.self)
+    )
+    
+    try? airportSearchService.loadAirports()
+    
     let authService = AuthService()
-    let tooltipService = TooltipService()
-    let searchHistoryService = SearchHistoryService()
     let bookSearchService = BookSearchService()
+    let searchHistoryService = SearchHistoryService()
+    let tooltipService = TooltipService()
     
     // MARK: - Builder
     let homeBuilder = HomeBuilder()
     let loginBuilder = LoginBuilder()
     let searchBuilder = SearchBuilder(
+      airportSearchService: airportSearchService,
       bookSearchService: bookSearchService,
       searchHistoryService: searchHistoryService
     )


### PR DESCRIPTION
## 관련 이슈 (Related Issue)

<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->

- #96 

---

## 작업 내용

<!-- 무엇을 변경했는지 간단히 설명 -->

- AirportSearchService의 생성 위치를 Builder에서 App 레이어로 이동하고, 생성자 주입 방식으로 수정

---

## 변경 사항

<!-- 주요 변경 사항을 작성 -->

- SearchBuilder 내부에서 AirportSearchService 직접 생성 로직 제거

---

## 스크린샷 / 영상 (UI 변경 시)

---

## 테스트

- [x] 로컬 빌드 확인
- [ ] 시뮬레이터 실행
- [ ] 테스트 코드 통과
- [ ] CI 통과

---

## 영향 범위

- [x] App
- [ ] Core
- [ ] DesignSystem
- [x] Feature
- [ ] Tuist
- [ ] CI / Fastlane

---

## 리뷰 포인트

<!-- 리뷰어가 집중해서 보면 좋은 부분 -->

### 수정 전
<img width="500" height="320" alt="스크린샷 2026-04-14 오후 8 36 58" src="https://github.com/user-attachments/assets/64b58465-8db4-4898-84d6-ddbbccf38583" /> <br>
- 빌더가 직접 서비스 구현체를 생성
- App은 빌더만 생성
- 빌더가 구현체를 직접 의존하는 구조

### 수정 후
<img width="500" height="320" alt="스크린샷 2026-04-14 오후 8 37 27" src="https://github.com/user-attachments/assets/c51d10f9-15c0-4cc5-ad7b-a3cb875a9236" /> <br>
- App이 구현체 생성
- 빌더는 인터페이스만 의존
- DI 흐름 명확해짐( 앱 -> 빌더 -> 뷰모델 -> 서비스(구현체) )

---

## 레퍼런스

<!-- 참고했던 레퍼런스 등 -->

---

## 체크리스트

- [x] 불필요한 코드 제거
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트
- [ ] CI 통과