### PR TITLE
refactor:#96 AuthService를 Builder에서 제거하고 외부 주입으로 변경

### DIFF
--- a/Features/Login/LoginFeature/Sources/Builders/LoginBuilder.swift
+++ b/Features/Login/LoginFeature/Sources/Builders/LoginBuilder.swift
@@ -12,10 +12,15 @@ import LoginInterface
 import UIKit
 
 public final class LoginBuilder: LoginBuildable {
-  public init() {}
+  let authService: AuthServicing
+  
+  public init(
+    authService: AuthServicing
+  ) {
+    self.authService = authService
+  }
   
   public func build(onLoginSuccess: @escaping () -> Void) -> UIViewController {
-    let authService = AuthService()
     let viewModel = LoginViewModel(authService: authService)
     let viewController = LoginViewController(viewModel: viewModel)
     viewController.onLoginSuccess = onLoginSuccess

--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -5,7 +5,7 @@
 //  Created by 여성일 on 3/1/26.
 //
 
-import AuthImplementation
+
 import Core
 import HomeFeature
 import LoginFeature
@@ -14,7 +14,9 @@ import SearchFeature
 import WishlistFeature
 import HistoryFeature
 import JourneyFeature
+
 import AirportSearchImplementation
+import AuthImplementation
 import BookSearchImplementation
 import SearchHistoryImplementation
 import TooltipImplementation
@@ -44,7 +46,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     let airportSearchService = AirportSearchService(
       bundle: Bundle(for: AirportSearchService.self)
     )
-    
     try? airportSearchService.loadAirports()
     
     let authService = AuthService()
@@ -54,7 +55,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     // MARK: - Builder
     let homeBuilder = HomeBuilder()
-    let loginBuilder = LoginBuilder()
+    let loginBuilder = LoginBuilder(
+      authService: authService
+    )
     let searchBuilder = SearchBuilder(
       airportSearchService: airportSearchService,
       bookSearchService: bookSearchService,


### PR DESCRIPTION
## 관련 이슈 (Related Issue)

<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->

- #96 

---

## 작업 내용

<!-- 무엇을 변경했는지 간단히 설명 -->

- AuthService의 생성 위치를 Builder에서 App 레이어로 이동하고, 생성자 주입 방식으로 수정

---

## 변경 사항

<!-- 주요 변경 사항을 작성 -->

- LoginBuilder 내부에서 AuthService 직접 생성 로직 제거

---

## 스크린샷 / 영상 (UI 변경 시)

---

## 테스트

- [x] 로컬 빌드 확인
- [ ] 시뮬레이터 실행
- [ ] 테스트 코드 통과
- [ ] CI 통과

---

## 영향 범위

- [x] App
- [ ] Core
- [ ] DesignSystem
- [x] Feature
- [ ] Tuist
- [ ] CI / Fastlane

---

## 리뷰 포인트

<!-- 리뷰어가 집중해서 보면 좋은 부분 -->

### 수정 전
 <img width="500" height="320" alt="스크린샷 2026-04-14 오후 8 46 09" src="https://github.com/user-attachments/assets/cad788d1-bc1f-4473-9853-3b1e9f571ba3" /> <br>
- 빌더가 직접 서비스 구현체를 생성
- App은 빌더만 생성
- 빌더가 구현체를 직접 의존하는 구조

### 수정 후
 <img width="500" height="320" alt="스크린샷 2026-04-14 오후 8 46 41" src="https://github.com/user-attachments/assets/a2013d4d-feb9-4eb5-aca4-6542b47f98e3" /> <br>
- App이 구현체 생성
- 빌더는 인터페이스만 의존
- DI 흐름 명확해짐( 앱 -> 빌더 -> 뷰모델 -> 서비스(구현체) )

---

## 레퍼런스

<!-- 참고했던 레퍼런스 등 -->

---

## 체크리스트

- [x] 불필요한 코드 제거
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트
- [ ] CI 통과