### PR TITLE
refactor:#96 ReadingJourneyService를 Builder에서 제거하고 외부 주입으로 변경

### DIFF
--- a/Features/History/HistoryFeature/Sources/Builders/DetailHistoryBuilder.swift
+++ b/Features/History/HistoryFeature/Sources/Builders/DetailHistoryBuilder.swift
@@ -9,16 +9,20 @@ import Core
 import UIKit
 import HistoryInterface
 import ReadingJourneyInterface
-import ReadingJourneyImplementation
 
 public final class DetailHistoryBuilder: DetailHistoryBuildable {
-  public init() {}
+  let readingJourneyService: ReadingJourneyServicing
+  
+  public init(
+    readingJourneyService: ReadingJourneyServicing
+  ) {
+    self.readingJourneyService = readingJourneyService
+  }
   
   public func build(
     journey: ReadingJourney,
     onRoute: ((DetailHistoryRoute) -> Void)? = nil
   ) -> UIViewController {
-    let readingJourneyService = ReadingJourneyService()
     let viewModel = DetailHistoryViewModel(
       journey: journey,
       readingJourneyService: readingJourneyService

--- a/Features/History/HistoryFeature/Sources/Builders/HistoryBuilder.swift
+++ b/Features/History/HistoryFeature/Sources/Builders/HistoryBuilder.swift
@@ -8,15 +8,20 @@
 import Core
 import UIKit
 import HistoryInterface
-import ReadingJourneyImplementation
+import ReadingJourneyInterface
 
 public final class HistoryBuilder: HistoryBuildable {
-  public init() {}
+  let readingJourneyService: ReadingJourneyServicing
+  
+  public init(
+    readingJourneyService: ReadingJourneyServicing
+  ) {
+    self.readingJourneyService = readingJourneyService
+  }
   
   public func build(
     onRoute: ((HistoryRoute) -> Void)?
   ) -> UIViewController {
-    let readingJourneyService = ReadingJourneyService()
     let viewModel = HistoryViewModel(
       readingJourneyService: readingJourneyService
     )

--- a/Features/History/HistoryFeature/Sources/Builders/RegisterHistoryBuilder.swift
+++ b/Features/History/HistoryFeature/Sources/Builders/RegisterHistoryBuilder.swift
@@ -8,15 +8,20 @@
 import Core
 import UIKit
 import HistoryInterface
-import ReadingJourneyImplementation
+import ReadingJourneyInterface
 
 public final class RegisterHistoryBuilder: RegisterHistoryBuildable {
-  public init() {}
+  let readingJourneyService: ReadingJourneyServicing
+  
+  public init(
+    readingJourneyService: ReadingJourneyServicing
+  ) {
+    self.readingJourneyService = readingJourneyService
+  }
   
   public func build(
     onRoute: ((RegisterHistoryRoute) -> Void)?
   ) -> UIViewController {
-    let readingJourneyService = ReadingJourneyService()
     let viewModel = RegisterHistoryViewModel(readingJourneyService: readingJourneyService)
     
     let viewController = RegisterHistoryViewController(viewModel: viewModel)

--- a/Features/Home/HomeFeature/Sources/Builders/HomeBuilder.swift
+++ b/Features/Home/HomeFeature/Sources/Builders/HomeBuilder.swift
@@ -9,15 +9,19 @@ import Core
 import HomeInterface
 import UIKit
 import ReadingJourneyInterface
-import ReadingJourneyImplementation
 
 public final class HomeBuilder: HomeBuildable {
-  public init() {}
+  let readingJourneyService: ReadingJourneyServicing
+  
+  public init(
+    readingJourneyService: ReadingJourneyServicing
+  ) {
+    self.readingJourneyService = readingJourneyService
+  }
 
   public func build(
     onRoute: @escaping (HomeRoute) -> Void
   ) -> UIViewController {
-    let readingJourneyService = ReadingJourneyService()
     let viewModel = HomeViewModel(readingJourneyService: readingJourneyService)
     let viewController = HomeViewController(viewModel: viewModel)
     

--- a/Features/Journey/JourneyFeature/Sources/Builders/JourneyBuilder.swift
+++ b/Features/Journey/JourneyFeature/Sources/Builders/JourneyBuilder.swift
@@ -8,25 +8,30 @@
 import Core
 import UIKit
 import JourneyInterface
+import ReadingJourneyInterface
 import TooltipInterface
-import ReadingJourneyImplementation
 
 public final class JourneyBuilder: JourneyBuildable {
+  private let journeyMemoService: JourneyMemoServicing
+  private let readingJourneyService: ReadingJourneyServicing
   private let tooltipService: TooltipServicing
+
   public init(
+    journeyMemoService: JourneyMemoServicing,
+    readingJourneyService: ReadingJourneyServicing,
     tooltipService: TooltipServicing
   ) {
+    self.journeyMemoService = journeyMemoService
+    self.readingJourneyService = readingJourneyService
     self.tooltipService = tooltipService
   }
   
   public func build(
     onRoute: ((JourneyRoute) -> Void)?
   ) -> UIViewController {
-    let readingJourneyService = ReadingJourneyService()
-    let memoService = JourneyMemoService()
     let viewModel = JourneyViewModel(
       readingJourneyService: readingJourneyService,
-      memoService: memoService,
+      memoService: journeyMemoService,
       tooltipService: tooltipService
     )
     let viewController = JourneyViewController(viewModel: viewModel)

--- a/Features/Journey/JourneyFeature/Sources/Builders/JourneyTicketBuilder.swift
+++ b/Features/Journey/JourneyFeature/Sources/Builders/JourneyTicketBuilder.swift
@@ -9,16 +9,20 @@ import Core
 import UIKit
 import JourneyInterface
 import ReadingJourneyInterface
-import ReadingJourneyImplementation
 
 public final class JourneyTicketBuilder: JourneyTicketBuildable {
-  public init() {}
+  private let readingJourneyService: ReadingJourneyServicing
+  
+  public init(
+    readingJourneyService: ReadingJourneyServicing
+  ) {
+    self.readingJourneyService = readingJourneyService
+  }
   
   public func build(
     payload: JourneyPayload,
     onRoute: @escaping (JourneyTicketRoute) -> Void
   ) -> UIViewController {
-    let readingJourneyService = ReadingJourneyService()
     let viewModel = JourneyTicketViewModel(
       payload: payload,
       readingJourneyService: readingJourneyService

--- a/Features/Wishlist/WishlistFeature/Sources/Builders/CheckInWishTicketBuilder.swift
+++ b/Features/Wishlist/WishlistFeature/Sources/Builders/CheckInWishTicketBuilder.swift
@@ -9,16 +9,20 @@ import Core
 import UIKit
 import WishlistInterface
 import ReadingJourneyInterface
-import ReadingJourneyImplementation
 
 public final class CheckInWishTicketBuilder: CheckInWishTicketBuildable {
-  public init() {}
+  let readingJourneyService: ReadingJourneyServicing
+  
+  public init(
+    readingJourneyService: ReadingJourneyServicing
+  ) {
+    self.readingJourneyService = readingJourneyService
+  }
   
   public func build(
     journey: ReadingJourney,
     onRoute: @escaping (CheckInWishTicketRoute) -> Void
   ) -> UIViewController {
-    let readingJourneyService = ReadingJourneyService()
     let viewModel = CheckInWishTicketViewModel(
       journey: journey,
       readingJourneyService: readingJourneyService

--- a/Features/Wishlist/WishlistFeature/Sources/Builders/WishTicketBuilder.swift
+++ b/Features/Wishlist/WishlistFeature/Sources/Builders/WishTicketBuilder.swift
@@ -12,13 +12,18 @@ import ReadingJourneyImplementation
 import ReadingJourneyInterface
 
 public final class WishTicketBuilder: WishTicketBuildable {
-  public init() {}
+  let readingJourneyService: ReadingJourneyServicing
+  
+  public init(
+    readingJourneyService: ReadingJourneyServicing
+  ) {
+    self.readingJourneyService = readingJourneyService
+  }
   
   public func build(
     payload: WishlistTicketPayload,
     onRoute: @escaping (WishTicketRoute) -> Void
   ) -> UIViewController {
-    let readingJourneyService = ReadingJourneyService()
     let viewModel = WishTicketViewModel(
       payload: payload,
       readingJourneyService: readingJourneyService

--- a/Features/Wishlist/WishlistFeature/Sources/Builders/WishlistBuilder.swift
+++ b/Features/Wishlist/WishlistFeature/Sources/Builders/WishlistBuilder.swift
@@ -9,22 +9,23 @@ import Core
 import UIKit
 import WishlistInterface
 import TooltipInterface
-import ReadingJourneyImplementation
+import ReadingJourneyInterface
 
 public final class WishlistBuilder: WishlistBuildable {
+  let readingJourneyService: ReadingJourneyServicing
   let tooltipService: TooltipServicing
   
   public init(
+    readingJourneyService: ReadingJourneyServicing,
     tooltipService: TooltipServicing
   ) {
+    self.readingJourneyService = readingJourneyService
     self.tooltipService = tooltipService
   }
   
   public func build(
     onRoute: @escaping (WishlistRoute) -> Void
   ) -> UIViewController {
-    let readingJourneyService = ReadingJourneyService()
-    let tooltipService = tooltipService
     let viewModel = WishlistViewModel(
       readingJourneyService: readingJourneyService,
       tooltipService: tooltipService

--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -76,7 +76,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
       readingJourneyService: readingJourneyService
     )
     let registerJourneyBuilder = RegisterJourneyBuilder()
-    let journeyTicketBuilder = JourneyTicketBuilder()
+    let journeyTicketBuilder = JourneyTicketBuilder(
+      readingJourneyService: readingJourneyService
+    )
     let journeyBuilder = JourneyBuilder(
       journeyMemoService: journeymemoService,
       readingJourneyService: readingJourneyService,

--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -67,6 +67,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
       searchHistoryService: searchHistoryService
     )
     let wishlistBuilder = WishlistBuilder(
+      readingJourneyService: readingJourneyService,
       tooltipService: tooltipService
     )
     let registerWishlistBuilder = RegisterWishlistBuilder()

--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -71,7 +71,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     let registerWishlistBuilder = RegisterWishlistBuilder()
     let wishTicketBuilder = WishTicketBuilder()
     let checkInWishTicketBuilder = CheckInWishTicketBuilder()
-    let registerHistoryBuilder = RegisterHistoryBuilder()
+    let registerHistoryBuilder = RegisterHistoryBuilder(
+      readingJourneyService: readingJourneyService
+    )
     let registerJourneyBuilder = RegisterJourneyBuilder()
     let journeyTicketBuilder = JourneyTicketBuilder()
     let journeyBuilder = JourneyBuilder(

--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -51,6 +51,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     let authService = AuthService()
     let bookSearchService = BookSearchService()
+    let journeymemoService = JourneyMemoService()
     let readingJourneyService = ReadingJourneyService()
     let searchHistoryService = SearchHistoryService()
     let tooltipService = TooltipService()
@@ -77,6 +78,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     let registerJourneyBuilder = RegisterJourneyBuilder()
     let journeyTicketBuilder = JourneyTicketBuilder()
     let journeyBuilder = JourneyBuilder(
+      journeyMemoService: journeymemoService,
+      readingJourneyService: readingJourneyService,
       tooltipService: tooltipService
     )
     let historyBuilder = HistoryBuilder(

--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -71,7 +71,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
       tooltipService: tooltipService
     )
     let registerWishlistBuilder = RegisterWishlistBuilder()
-    let wishTicketBuilder = WishTicketBuilder()
+    let wishTicketBuilder = WishTicketBuilder(
+      readingJourneyService: readingJourneyService
+    )
     let checkInWishTicketBuilder = CheckInWishTicketBuilder(
       readingJourneyService: readingJourneyService
     )

--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -18,6 +18,7 @@ import JourneyFeature
 import AirportSearchImplementation
 import AuthImplementation
 import BookSearchImplementation
+import ReadingJourneyImplementation
 import SearchHistoryImplementation
 import TooltipImplementation
 
@@ -50,6 +51,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     let authService = AuthService()
     let bookSearchService = BookSearchService()
+    let readingJourneyService = ReadingJourneyService()
     let searchHistoryService = SearchHistoryService()
     let tooltipService = TooltipService()
     
@@ -76,7 +78,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
       tooltipService: tooltipService
     )
     let historyBuilder = HistoryBuilder()
-    let detailHistoryBuilder = DetailHistoryBuilder()
+    let detailHistoryBuilder = DetailHistoryBuilder(
+      readingJourneyService: readingJourneyService
+    )
     
     let coordinator = AppCoordinator(
       navigationController: navigationController,

--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -71,7 +71,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     )
     let registerWishlistBuilder = RegisterWishlistBuilder()
     let wishTicketBuilder = WishTicketBuilder()
-    let checkInWishTicketBuilder = CheckInWishTicketBuilder()
+    let checkInWishTicketBuilder = CheckInWishTicketBuilder(
+      readingJourneyService: readingJourneyService
+    )
     let registerHistoryBuilder = RegisterHistoryBuilder(
       readingJourneyService: readingJourneyService
     )

--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -77,7 +77,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     let journeyBuilder = JourneyBuilder(
       tooltipService: tooltipService
     )
-    let historyBuilder = HistoryBuilder()
+    let historyBuilder = HistoryBuilder(
+      readingJourneyService: readingJourneyService
+    )
     let detailHistoryBuilder = DetailHistoryBuilder(
       readingJourneyService: readingJourneyService
     )


### PR DESCRIPTION
## 관련 이슈 (Related Issue)

<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->

- #96 

---

## 작업 내용

<!-- 무엇을 변경했는지 간단히 설명 -->

- ReadingJourneyService의 생성 위치를 Builder에서 App 레이어로 이동하고, 생성자 주입 방식으로 수정

---

## 변경 사항

<!-- 주요 변경 사항을 작성 -->

- HomeBuilder 내부에서 ReadingJourneyService 직접 생성 로직 제거
- HistoryBuilder 내부에서 ReadingJourneyService 직접 생성 로직 제거
- RegisterHistoryBuilder 내부에서 ReadingJourneyService 직접 생성 로직 제거
- DetailHistoryBuilder 내부에서 ReadingJourneyService 직접 생성 로직 제거
- JourneyBuilder 내부에서 ReadingJourneyService 직접 생성 로직 제거
- JourneyTicketBuilder 내부에서 ReadingJourneyService 직접 생성 로직 제거
- CheckInWishTicketBuilder 내부에서 ReadingJourneyService 직접 생성 로직 제거
- WishlistBuilder 내부에서 ReadingJourneyService 직접 생성 로직 제거
- WishTicketBuilder 내부에서 ReadingJourneyService 직접 생성 로직 제거

---

## 스크린샷 / 영상 (UI 변경 시)

---

## 테스트

- [x] 로컬 빌드 확인
- [ ] 시뮬레이터 실행
- [ ] 테스트 코드 통과
- [ ] CI 통과

---

## 영향 범위

- [x] App
- [ ] Core
- [ ] DesignSystem
- [x] Feature
- [ ] Tuist
- [ ] CI / Fastlane

---

## 리뷰 포인트

<!-- 리뷰어가 집중해서 보면 좋은 부분 -->

### 수정 전
 <img width="500" height="320" alt="스크린샷 2026-04-14 오후 10 43 40" src="https://github.com/user-attachments/assets/9f639e82-b38f-4629-83fc-9f65b4870150" /> <br>
- 빌더가 직접 서비스 구현체를 생성
- App은 빌더만 생성
- 빌더가 구현체를 직접 의존하는 구조

### 수정 후
<img width="500" height="320" alt="스크린샷 2026-04-14 오후 10 55 06" src="https://github.com/user-attachments/assets/0b81aea3-b1fb-48c2-89c9-690876e7ff4f" /> <br>
- App이 구현체 생성
- 빌더는 인터페이스만 의존
- DI 흐름 명확해짐( 앱 -> 빌더 -> 뷰모델 -> 서비스(구현체) )

---

## 레퍼런스

<!-- 참고했던 레퍼런스 등 -->

---

## 체크리스트

- [x] 불필요한 코드 제거
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트
- [ ] CI 통과