### PR TITLE
feature:#122 스플래시 프리로드 구현

### DIFF
--- a/Features/Home/HomeFeature/Sources/Builders/HomeBuilder.swift
+++ b/Features/Home/HomeFeature/Sources/Builders/HomeBuilder.swift
@@ -20,13 +20,20 @@ public final class HomeBuilder: HomeBuildable {
   }
 
   public func build(
+    preloadedJourneys: [ReadingJourney] = [],
     onRoute: @escaping (HomeRoute) -> Void
-  ) -> UIViewController {
-    let viewModel = HomeViewModel(readingJourneyService: readingJourneyService)
+  ) -> (viewController: UIViewController, refresh: () -> Void) {
+    let viewModel = HomeViewModel(
+      readingJourneyService: readingJourneyService,
+      preloadedJourneys: preloadedJourneys
+    )
     let viewController = HomeViewController(viewModel: viewModel)
-    
     viewController.onRoute = onRoute
-    
-    return viewController
+
+    let refresh: () -> Void = {
+      Task { await viewModel.refresh() }
+    }
+
+    return (viewController, refresh)
   }
 }

--- a/Features/Home/HomeFeature/Sources/ViewControllers/HomeViewController.swift
+++ b/Features/Home/HomeFeature/Sources/ViewControllers/HomeViewController.swift
@@ -36,6 +36,7 @@ public final class HomeViewController: BaseViewController {
   public override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
     
+    guard viewModel.journeys.isEmpty else { return }
     Task { [weak self] in
       await self?.viewModel.refresh()
     }

--- a/Features/Home/HomeFeature/Sources/ViewControllers/HomeViewController.swift
+++ b/Features/Home/HomeFeature/Sources/ViewControllers/HomeViewController.swift
@@ -37,7 +37,7 @@ public final class HomeViewController: BaseViewController {
     super.viewDidAppear(animated)
     
     Task { [weak self] in
-      await self?.viewModel.loadReadingJourneys()
+      await self?.viewModel.refresh()
     }
   }
   

--- a/Features/Home/HomeFeature/Sources/ViewModels/HomeViewModel.swift
+++ b/Features/Home/HomeFeature/Sources/ViewModels/HomeViewModel.swift
@@ -22,9 +22,11 @@ public final class HomeViewModel {
   }
   
   public init(
-    readingJourneyService: ReadingJourneyServicing
+    readingJourneyService: ReadingJourneyServicing,
+    preloadedJourneys: [ReadingJourney] = []
   ) {
     self.readingJourneyService = readingJourneyService
+    self.journeys = preloadedJourneys
   }
   
   var greetingText: String {
@@ -55,20 +57,20 @@ public final class HomeViewModel {
   }
   
   // MARK: - Public Method
-  func loadReadingJourneys() async {
-    do {
-      journeys = try await readingJourneyService.fetchReadingJourneys()
-    } catch {
-      let message = (error as? LocalizedError)?.errorDescription ?? "여행 정보를 불러오지 못했습니다."
-      onError?(message)
-    }
-  }
-  
   func calculateProgress(journey: ReadingJourney) -> Double {
     guard let currentPage = journey.currentPage, journey.book.itemPage > 0 else {
       return 0
     }
     
     return min(max(Double(currentPage) / Double(journey.book.itemPage), 0), 1)
+  }
+  
+  func refresh() async {
+    do {
+      journeys = try await readingJourneyService.fetchReadingJourneys()
+    } catch {
+      let message = (error as? LocalizedError)?.errorDescription ?? "여행 데이터를 불러오지 못했습니다."
+      onError?(message)
+    }
   }
 }

--- a/Features/Home/HomeInterface/Sources/Buildables/HomeBuildable.swift
+++ b/Features/Home/HomeInterface/Sources/Buildables/HomeBuildable.swift
@@ -5,10 +5,12 @@
 //  Created by 여성일 on 3/8/26.
 //
 
+import ReadingJourneyInterface
 import UIKit
 
 public protocol HomeBuildable {
   func build(
+    preloadedJourneys: [ReadingJourney],
     onRoute: @escaping (HomeRoute) -> Void
-  ) -> UIViewController
+  ) -> (viewController: UIViewController, refresh: () -> Void)
 }

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -109,7 +109,8 @@ let project = Project(
       sources: ["Tests/**"],
       dependencies: [
         .target(name: "FlyleafDev"),
-        .service(.auth, .interface)
+        .service(.auth, .interface),
+        .service(.readingJourney, .interface)
       ]
     ),
     .target(

--- a/Projects/App/Sources/Coordiators/AppCoordinator.swift
+++ b/Projects/App/Sources/Coordiators/AppCoordinator.swift
@@ -26,6 +26,7 @@ final class AppCoordinator: NSObject, Coordinator {
   
   private let authService: AuthServicing
   private let readingJourneyService: ReadingJourneyServicing
+  private var refreshHome: (() -> Void)?
   
   private let homeBuilder: HomeBuildable
   private let loginBuilder: LoginBuildable
@@ -104,7 +105,7 @@ final class AppCoordinator: NSObject, Coordinator {
       self?.showLogin()
     }
     coordinator.onReadyToMain = { [weak self] journeys in
-      self?.showMainTabBar()
+      self?.showMainTabBar(preloadedJourneys: journeys)
     }
     
     childCoordinators.append(coordinator)
@@ -114,8 +115,9 @@ final class AppCoordinator: NSObject, Coordinator {
 
 // MARK: - MainTabBar
 private extension AppCoordinator {
-  func showMainTabBar() {
-    let homeVC = homeBuilder.build(
+  func showMainTabBar(preloadedJourneys: [ReadingJourney]) {
+    let (homeVC, refresh) = homeBuilder.build(
+      preloadedJourneys: preloadedJourneys,
       onRoute: { [weak self] route in
         switch route {
         case .wishlist:
@@ -129,6 +131,8 @@ private extension AppCoordinator {
         }
       }
     )
+    
+    refreshHome = refresh
     
     let journeyVC = jourenyBuilder.build(
       onRoute: { [weak self] route in
@@ -227,7 +231,7 @@ private extension AppCoordinator {
     coordinator.parentCoordinator = self
     coordinator.onLoginCompleted = { [weak self] in
       guard let self = self else { return }
-      self.showMainTabBar()
+      self.showMainTabBar(preloadedJourneys: [])
       self.childDidFinish(coordinator)
     }
     
@@ -265,8 +269,10 @@ private extension AppCoordinator {
       switch event {
       case .moveToWishlistTab:
         self.moveToTab(.wishlist)
+        self.refreshHome?()
       case .moveToJourneyTab:
         self.moveToTab(.journey)
+        self.refreshHome?()
       }
     }
     
@@ -301,6 +307,7 @@ private extension AppCoordinator {
       switch event {
       case .moveToHistoryTab:
         self?.moveToTab(.history)
+        self?.refreshHome?()
       }
     }
     
@@ -329,6 +336,7 @@ private extension AppCoordinator {
       switch event {
       case .moveToJourneyTab:
         self?.moveToTab(.journey)
+        self?.refreshHome?()
       }
     }
     

--- a/Projects/App/Sources/Coordiators/AppCoordinator.swift
+++ b/Projects/App/Sources/Coordiators/AppCoordinator.swift
@@ -25,6 +25,8 @@ final class AppCoordinator: NSObject, Coordinator {
   var rootViewController: UIViewController?
   
   private let authService: AuthServicing
+  private let readingJourneyService: ReadingJourneyServicing
+  
   private let homeBuilder: HomeBuildable
   private let loginBuilder: LoginBuildable
   private let searchBuilder: SearchBuildable
@@ -46,6 +48,7 @@ final class AppCoordinator: NSObject, Coordinator {
   init(
     navigationController: UINavigationController,
     authService: AuthServicing,
+    readingJourneyService: ReadingJourneyServicing,
     homeBuilder: HomeBuildable,
     loginBuilder: LoginBuildable,
     searchBuilder: SearchBuildable,
@@ -66,6 +69,7 @@ final class AppCoordinator: NSObject, Coordinator {
   ) {
     self.navigationController = navigationController
     self.authService = authService
+    self.readingJourneyService = readingJourneyService
     self.homeBuilder = homeBuilder
     self.loginBuilder = loginBuilder
     self.searchBuilder = searchBuilder
@@ -90,34 +94,21 @@ final class AppCoordinator: NSObject, Coordinator {
   }
   
   func start() {
-    // routeInitialFlow은 case 3때 활용
-    // routeInitialFlow()
-    showSplash()
-  }
-  
-  private func showSplash() {
-    let viewModel = SplashViewModel(authService: authService)
-    let splashVC = SplashViewController(viewModel: viewModel)
-    
-    splashVC.onRoute = { [weak self] result in
-      switch result {
-      case .needsLogin:
-        self?.showLogin()
-      case .readyToMain:
-        self?.showMainTabBar()
-      }
+    let coordinator = SplashCoordinator(
+      navigationController: navigationController,
+      authService: authService,
+      readingJourneyService: readingJourneyService
+    )
+    coordinator.parentCoordinator = self
+    coordinator.onNeedsLogin = { [weak self] in
+      self?.showLogin()
+    }
+    coordinator.onReadyToMain = { [weak self] journeys in
+      self?.showMainTabBar()
     }
     
-    navigationController.setViewControllers([splashVC], animated: false)
-  }
-  
-  // routeInitialFlow은 case 3때 활용
-  private func routeInitialFlow() {
-    if authService.isSignedIn {
-      showMainTabBar()
-    } else {
-      showLogin()
-    }
+    childCoordinators.append(coordinator)
+    coordinator.start()
   }
 }
 

--- a/Projects/App/Sources/Coordiators/SplashCoordinator.swift
+++ b/Projects/App/Sources/Coordiators/SplashCoordinator.swift
@@ -1,0 +1,54 @@
+//
+//  SplashCoordinator.swift
+//  App
+//
+//  Created by 여성일 on 5/31/26.
+//
+
+import AuthInterface
+import ReadingJourneyInterface
+import UIKit
+
+@MainActor
+final class SplashCoordinator: Coordinator {
+  weak var parentCoordinator: Coordinator?
+  var childCoordinators: [Coordinator] = []
+  let navigationController: UINavigationController
+  var rootViewController: UIViewController?
+  
+  private let authService: AuthServicing
+  private let readingJourneyService: ReadingJourneyServicing
+  
+  var onNeedsLogin: (() -> Void)?
+  var onReadyToMain: (([ReadingJourney]) -> Void)?
+  
+  init(
+    navigationController: UINavigationController,
+    authService: AuthServicing,
+    readingJourneyService: ReadingJourneyServicing
+  ) {
+    self.navigationController = navigationController
+    self.authService = authService
+    self.readingJourneyService = readingJourneyService
+  }
+  
+  func start() {
+    let viewModel = SplashViewModel(
+      authService: authService,
+      readingJourneyService: readingJourneyService
+    )
+    
+    let splashVC = SplashViewController(viewModel: viewModel)
+    
+    splashVC.onRoute = { [weak self] result in
+      switch result {
+      case .needsLogin:
+        self?.onNeedsLogin?()
+      case .readyToMain(let journeys):
+        self?.onReadyToMain?(journeys)
+      }
+    }
+    
+    navigationController.setViewControllers([splashVC], animated: false)
+  }
+}

--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -181,6 +181,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
       AppCoordinator(
         navigationController: navigationController,
         authService: container.resolve(AuthServicing.self)!,
+        readingJourneyService: container.resolve(ReadingJourneyServicing.self)!,
         homeBuilder: container.resolve(HomeBuilder.self)!,
         loginBuilder: container.resolve(LoginBuilder.self)!,
         searchBuilder: container.resolve(SearchBuilder.self)!,

--- a/Projects/App/Sources/Splash/SplashLoadingStep.swift
+++ b/Projects/App/Sources/Splash/SplashLoadingStep.swift
@@ -7,6 +7,7 @@
 
 enum SplashLoadingStep {
   case checkingAuth
+  case fetchingData
 }
 
 extension SplashLoadingStep {
@@ -14,6 +15,8 @@ extension SplashLoadingStep {
     switch self {
     case .checkingAuth:
       return "로그인 정보를 확인하고 있어요"
+    case .fetchingData:
+      return "여행 데이터를 불러오고 있어요"
     }
   }
 }

--- a/Projects/App/Sources/Splash/SplashResult.swift
+++ b/Projects/App/Sources/Splash/SplashResult.swift
@@ -7,7 +7,7 @@
 
 import ReadingJourneyInterface
 
-enum SplashResult {
+enum SplashResult: Equatable {
   case needsLogin
   case readyToMain([ReadingJourney])
 }

--- a/Projects/App/Sources/Splash/SplashResult.swift
+++ b/Projects/App/Sources/Splash/SplashResult.swift
@@ -5,7 +5,9 @@
 //  Created by 여성일 on 5/30/26.
 //
 
+import ReadingJourneyInterface
+
 enum SplashResult {
   case needsLogin
-  case readyToMain
+  case readyToMain([ReadingJourney])
 }

--- a/Projects/App/Sources/Splash/ViewModels/SplashViewModel.swift
+++ b/Projects/App/Sources/Splash/ViewModels/SplashViewModel.swift
@@ -7,21 +7,26 @@
 
 import AuthInterface
 import Foundation
+import ReadingJourneyInterface
 
 final class SplashViewModel {
   private let authService: AuthServicing
+  private let readingJourneyService: ReadingJourneyServicing
   private let minimumDisplayDuration: Duration
 
   init(
     authService: AuthServicing,
+    readingJourneyService: ReadingJourneyServicing,
     minimumDisplayDuration: Duration = .seconds(1.5)
   ) {
     self.authService = authService
+    self.readingJourneyService = readingJourneyService
     self.minimumDisplayDuration = minimumDisplayDuration
   }
 
   var onStepChanged: ((SplashLoadingStep) -> Void)?
   var onCompleted: ((SplashResult) -> Void)?
+  var onError: ((String) -> Void)?
 
   func startLoading() async {
     onStepChanged?(.checkingAuth)
@@ -37,7 +42,16 @@ final class SplashViewModel {
       return
     }
 
-    onCompleted?(.readyToMain)
+    onStepChanged?(.fetchingData)
+    
+    do {
+      let journeys = try await readingJourneyService.fetchReadingJourneys()
+      onCompleted?(.readyToMain(journeys))
+    } catch {
+      let message = (error as? LocalizedError)?.errorDescription ?? "여행 데이터를 불러오지 못했습니다."
+      onError?(message)
+      onCompleted?(.readyToMain([]))
+    }
   }
 }
 

--- a/Projects/App/Tests/Mocks/MockAuthService.swift
+++ b/Projects/App/Tests/Mocks/MockAuthService.swift
@@ -11,21 +11,18 @@ import Core
 final class MockAuthService: AuthServicing {
   var isSignedIn: Bool = false
   var currentUser: AppUser? = nil
-  
+
   var signInResult: Result<AppUser, Error> = .success(
     AppUser(id: "1", name: "테스트", email: "test@test.com")
   )
-  
+
   func signInWithApple(payload: AppleLoginPayload) async throws -> AppUser {
     switch signInResult {
-    case .success(let user):
-      return user
-    case .failure(let error):
-      throw error
+    case .success(let user): return user
+    case .failure(let error): throw error
     }
   }
-  
-  func signOut() throws {}
 
+  func signOut() throws {}
   func deleteAccount() async throws {}
 }

--- a/Projects/App/Tests/Mocks/MockReadingJourneyService.swift
+++ b/Projects/App/Tests/Mocks/MockReadingJourneyService.swift
@@ -1,0 +1,43 @@
+//
+//  MockReadingJourneyService.swift
+//  App
+//
+//  Created by 여성일 on 5/31/26.
+//
+
+import ReadingJourneyInterface
+import Foundation
+
+final class MockReadingJourneyService: ReadingJourneyServicing {
+  var stubbedFetchReadingJourneysResult: [ReadingJourney] = []
+  var stubbedFetchReadingJourneysError: Error?
+
+  func fetchReadingJourneys() async throws -> [ReadingJourney] {
+    if let error = stubbedFetchReadingJourneysError { throw error }
+    return stubbedFetchReadingJourneysResult
+  }
+
+  func createWishlistJourney(payload: WishlistTicketPayload) async throws -> ReadingJourney { fatalError() }
+  func createHistoryJourney(payload: HistoryPayload) async throws -> ReadingJourney { fatalError() }
+  func createJourney(payload: JourneyPayload) async throws -> ReadingJourney { fatalError() }
+  func finishJourney(journeyId: String, review: String) async throws -> ReadingJourney { fatalError() }
+  func updateJourneyCurrentPage(journeyId: String, currentPage: Int) async throws -> ReadingJourney { fatalError() }
+  func fetchFinishedJourneys() async throws -> [ReadingJourney] { fatalError() }
+  func fetchWishlist() async throws -> [ReadingJourney] { fatalError() }
+  func updateJourneyStatusToReading(journeyId: String, startDate: Date, currentPage: Int) async throws -> ReadingJourney { fatalError() }
+  func updateFinishedJourneyDates(journeyId: String, startDate: Date, finishDate: Date) async throws -> ReadingJourney { fatalError() }
+  func updateFinishedJourneyReview(journeyId: String, review: String) async throws -> ReadingJourney { fatalError() }
+  func deleteReadingJourney(journeyId: String) async throws { fatalError() }
+  func deleteWishlistJourney(journeyId: String) async throws { fatalError() }
+  func deleteFinishedJourney(journeyId: String) async throws { fatalError() }
+}
+
+enum MockReadingJourneyError: LocalizedError {
+  case fetchFailed
+
+  var errorDescription: String? {
+    switch self {
+    case .fetchFailed: return "여행 데이터를 불러오지 못했습니다."
+    }
+  }
+}

--- a/Projects/App/Tests/SplashViewModelTests.swift
+++ b/Projects/App/Tests/SplashViewModelTests.swift
@@ -6,18 +6,23 @@
 //
 
 import XCTest
+import Core
+import ReadingJourneyInterface
 @testable import FlyleafDev
 
 final class SplashViewModelTests: XCTestCase {
   private var sut: SplashViewModel!
   private var mockAuthService: MockAuthService!
+  private var mockReadingJourneyService: MockReadingJourneyService!
 
   override func setUp() {
     super.setUp()
     UserDefaults.standard.removeObject(forKey: "hasLaunchedBefore")
     mockAuthService = MockAuthService()
+    mockReadingJourneyService = MockReadingJourneyService()
     sut = SplashViewModel(
       authService: mockAuthService,
+      readingJourneyService: mockReadingJourneyService,
       minimumDisplayDuration: .seconds(0)
     )
   }
@@ -26,6 +31,7 @@ final class SplashViewModelTests: XCTestCase {
     UserDefaults.standard.removeObject(forKey: "hasLaunchedBefore")
     sut = nil
     mockAuthService = nil
+    mockReadingJourneyService = nil
     super.tearDown()
   }
 
@@ -46,7 +52,7 @@ final class SplashViewModelTests: XCTestCase {
   }
 
   /*
-   로그아웃 상태에서 needsLogin으로 라우팅되는지 검증하는 테스트
+   재방문 + 로그아웃 상태에서 needsLogin으로 라우팅되는지 검증하는 테스트
 
    - Given: 재방문 + 로그아웃 상태
    - When: startLoading() 호출
@@ -65,37 +71,132 @@ final class SplashViewModelTests: XCTestCase {
   }
 
   /*
-   로그인 상태에서 readyToMain으로 라우팅되는지 검증하는 테스트
+   재방문 + 로그인 상태에서 패치 성공 시 readyToMain(journeys)으로 라우팅되는지 검증하는 테스트
 
-   - Given: 재방문 + 로그인 상태
+   - Given: 재방문 + 로그인 상태, 패치 성공
    - When: startLoading() 호출
-   - Then: onCompleted가 .readyToMain으로 호출되는지 확인합니다.
+   - Then: onCompleted가 .readyToMain(journeys)으로 호출되는지 확인합니다.
    */
-  func test_startLoading_whenSignedIn_callsReadyToMain() async {
+  func test_startLoading_whenSignedIn_andFetchSuccess_callsReadyToMainWithJourneys() async {
     UserDefaults.standard.set(true, forKey: "hasLaunchedBefore")
     mockAuthService.isSignedIn = true
+    mockReadingJourneyService.stubbedFetchReadingJourneysResult = [
+      makeReadingJourney(id: "journey-1")
+    ]
 
     var receivedResult: SplashResult?
     sut.onCompleted = { receivedResult = $0 }
 
     await sut.startLoading()
 
-    XCTAssertEqual(receivedResult, .readyToMain)
+    XCTAssertEqual(receivedResult, .readyToMain([makeReadingJourney(id: "journey-1")]))
   }
 
   /*
-   로딩 시작 시 onStepChanged가 .checkingAuth로 호출되는지 검증하는 테스트
+   재방문 + 로그인 상태에서 패치 실패 시 onError와 readyToMain([])이 호출되는지 검증하는 테스트
 
-   - Given: SplashViewModel
+   - Given: 재방문 + 로그인 상태, 패치 실패
    - When: startLoading() 호출
-   - Then: onStepChanged가 .checkingAuth로 호출되는지 확인합니다.
+   - Then: onError가 호출되고 onCompleted가 .readyToMain([])으로 호출되는지 확인합니다.
    */
-  func test_startLoading_callsOnStepChanged_withCheckingAuth() async {
-    var receivedStep: SplashLoadingStep?
-    sut.onStepChanged = { receivedStep = $0 }
+  func test_startLoading_whenSignedIn_andFetchFails_callsOnError_andReadyToMainWithEmpty() async {
+    UserDefaults.standard.set(true, forKey: "hasLaunchedBefore")
+    mockAuthService.isSignedIn = true
+    mockReadingJourneyService.stubbedFetchReadingJourneysError = MockReadingJourneyError.fetchFailed
+
+    var receivedResult: SplashResult?
+    var receivedError: String?
+    sut.onCompleted = { receivedResult = $0 }
+    sut.onError = { receivedError = $0 }
 
     await sut.startLoading()
 
-    XCTAssertEqual(receivedStep, .checkingAuth)
+    XCTAssertEqual(receivedError, "여행 데이터를 불러오지 못했습니다.")
+    XCTAssertEqual(receivedResult, .readyToMain([]))
+  }
+
+  /*
+   로딩 시작 시 checkingAuth 스텝으로 변경되는지 검증하는 테스트
+
+   - Given: SplashViewModel
+   - When: startLoading() 호출
+   - Then: onStepChanged가 .checkingAuth로 먼저 호출되는지 확인합니다.
+   */
+  func test_startLoading_callsOnStepChanged_withCheckingAuth() async {
+    var receivedSteps: [SplashLoadingStep] = []
+    sut.onStepChanged = { receivedSteps.append($0) }
+
+    await sut.startLoading()
+
+    XCTAssertTrue(receivedSteps.contains(.checkingAuth))
+  }
+
+  /*
+   로그인 상태일 때 checkingAuth → fetchingData 순서로 스텝이 변경되는지 검증하는 테스트
+
+   - Given: 재방문 + 로그인 상태
+   - When: startLoading() 호출
+   - Then: onStepChanged가 .checkingAuth → .fetchingData 순서로 호출되는지 확인합니다.
+   */
+  func test_startLoading_whenSignedIn_callsSteps_checkingAuth_then_fetchingData() async {
+    UserDefaults.standard.set(true, forKey: "hasLaunchedBefore")
+    mockAuthService.isSignedIn = true
+
+    var receivedSteps: [SplashLoadingStep] = []
+    sut.onStepChanged = { receivedSteps.append($0) }
+
+    await sut.startLoading()
+
+    XCTAssertEqual(receivedSteps, [.checkingAuth, .fetchingData])
+  }
+}
+
+// MARK: - Helper
+private extension SplashViewModelTests {
+  func makeReadingJourney(id: String = "journey-id") -> ReadingJourney {
+    ReadingJourney(
+      id: id,
+      status: .reading,
+      departureAirport: makeAirportInfo(iata: "CJJ"),
+      arrivalAirport: makeAirportInfo(iata: "FUK"),
+      distanceKm: 540,
+      remainingDistanceKm: 300,
+      book: makeBookInfo(),
+      reason: nil,
+      startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+      finishedAt: nil,
+      currentPage: 200,
+      progressUpdatedAt: nil,
+      review: nil,
+      createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+      updatedAt: nil,
+      lastUpdatedAt: Date(timeIntervalSince1970: 1_700_000_000)
+    )
+  }
+
+  func makeAirportInfo(iata: String) -> AirportInfo {
+    AirportInfo(
+      iata: iata,
+      airportNameEn: "Test Airport",
+      airportNameKo: "테스트 공항",
+      cityNameEn: "Test City",
+      cityNameKo: "테스트 도시",
+      countryNameKo: "테스트 국가",
+      latitude: 0,
+      longitude: 0,
+      searchText: iata
+    )
+  }
+
+  func makeBookInfo() -> BookInfo {
+    BookInfo(
+      isbn13: "9788937460616",
+      title: "테스트 도서",
+      author: "테스트 작가",
+      publisher: "테스트 출판사",
+      itemPage: 584,
+      cover: "https://example.com/cover.jpg",
+      description: "테스트"
+    )
   }
 }


### PR DESCRIPTION
## 관련 이슈 (Related Issue)

<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->

- Closes #122 

---

## 작업 내용

<!-- 무엇을 변경했는지 간단히 설명 -->

- 스플래시 화면에서 ReadingJourney 데이터를 미리 패치하여 홈 화면 진입 시 불필요한 로딩을 제거

---

## 변경 사항

<!-- 주요 변경 사항을 작성 -->

- SplashCoordinator 생성
- SplashViewModel에 ReadingJourneyServicing 의존성 추가 및 프리로드 로직 구현
- SplashResult.readyToMain에 프리로드 데이터 포함
- HomeBuildable, HomeBuilder 빌더 반환 타입 변경
- HomeViewModel 생성자에 preloadJourneys 주입 추가
- AppCoordinator에 refreshHome 클로저 추가

---

## 스크린샷 / 영상 (UI 변경 시)

| Before | After |
| ------ | ----- |
|        |       |

---

## 테스트

SplshViewModel 프리로드 단위 테스팅

- [x] 로컬 빌드 확인
- [x] 시뮬레이터 실행
- [x] 테스트 코드 통과
- [ ] CI 통과

---

## 영향 범위

- [x] App
- [ ] Core
- [ ] DesignSystem
- [x] Feature
- [x] Tuist
- [ ] CI / Fastlane

---

## 리뷰 포인트

<!-- 리뷰어가 집중해서 보면 좋은 부분 -->

1. **HomeBuilder 반환 타입 수정**
기존 build(onRoute:) -> UIViewController에서 build(preloadedJourneys:onRoute:) -> (viewController: UIViewController, refresh: () -> Void) 튜플으로 반환 타입 변경했습니다. AppCoordinator가 refresh 클로저를 보관하다가 여행 기록 등 플로우 완료 시 호출하는 방식으로, 홈 데이터 갱신 시점을 Coordinator 완료 콜백 기반으로 명시적으로 처리합니다.

2. **홈 데이터 갱신**
데이터 갱신을 NotificationCenter 대신 Coordinator 완료 콜백 기반으로 처리했습니다. NotificationCenter를 사용할 경우 누락 위험, 기존 Coordinator 기반 아키텍처와의 일관성 문제가 발생할 수 있다고 판단했습니다. Coordinator 완료 콜백 방식은 흐름이 명확하고 Flyleaf의 기존 클로저 기반 바인딩 패턴과도 일관성이 유지됩니다.

---

## 레퍼런스

<!-- 참고했던 레퍼런스 등 -->


---

## 체크리스트

- [x] 불필요한 코드 제거
- [x] 테스트 코드 작성
- [ ] 문서 업데이트
- [ ] CI 통과